### PR TITLE
fixed hero-container class margin from 0 to 2rem

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -216,7 +216,7 @@ body {
 
 .hero-container {
     max-width: 1200px;
-    margin: 0 auto;
+    margin: 2rem;
     padding: var(--container-padding);
     display: grid;
     grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
Fixes: issue #50 

Now the welcome text (inside the .hero-content class) is positioned correctly.

Image 1 : 

<img width="512" height="512" alt="Screenshot 2025-10-06 220743" src="https://github.com/user-attachments/assets/a000956a-3876-41b2-97a7-9dd7929f72f1" />

<br><br>
Image 2 : 

<img width="512" height="512" alt="Screenshot 2025-10-06 220802" src="https://github.com/user-attachments/assets/658272ee-fbb9-41bb-8849-2065bade384d" />
