### PR TITLE
Fixed the scroll indicator in the Hero section so it is now properly …

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -212,6 +212,7 @@ body {
     bottom: 0;
     background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grain" width="100" height="100" patternUnits="userSpaceOnUse"><circle cx="50" cy="50" r="1" fill="rgba(255,255,255,0.1)"/></pattern></defs><rect width="100" height="100" fill="url(%23grain)"/></svg>');
     opacity: 0.5;
+    pointer-events: none;
 }
 
 .hero-container {
@@ -224,7 +225,12 @@ body {
     align-items: center;
     position: relative;
     z-index: 2;
+    pointer-events: none !important;
 }
+
+.hero-container * {
+    pointer-events: auto !important;
+  }
 
 .hero-content {
     color: white;
@@ -413,15 +419,43 @@ body {
 }
 
 .scroll-indicator {
-    position: absolute;
+    position: fixed;
     bottom: 2rem;
     left: 50%;
     transform: translateX(-50%);
+    width: 70px;
+    height: 70px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background-color: transparent;
     color: white;
-    font-size: 1.5rem;
-    animation: bounce 2s infinite;
+    font-size: 2rem;
     cursor: pointer;
-}
+    z-index: 99999; /* Keep it above everything */
+    pointer-events: auto;
+  }
+  
+  .scroll-indicator::before {
+    content: "";
+    position: absolute;
+    inset: 0; /* fills the 70x70 area */
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.1);
+    transition: background 0.3s;
+    pointer-events: none; /* ensures the pseudo doesn't block clicks */
+  }
+  
+  .scroll-indicator:hover::before {
+    background: rgba(255, 255, 255, 0.2);
+  }
+  
+  .scroll-indicator i {
+    pointer-events: none; /* ensures the icon doesn't absorb the click */
+  }
+  
+  
 
 /* Features Section */
 .features {
@@ -1924,10 +1958,6 @@ html, body, .feature-card, .food-card, .navbar, .modal-content, .footer, .stats-
     to { transform: rotate(360deg); }
 }
 
-.scroll-indicator {
-    animation: bounceArrow 2s ease-in-out infinite;
-}
-
 @keyframes bounceArrow {
     0%, 20%, 50%, 80%, 100% {
         transform: translateX(-50%) translateY(0);
@@ -2161,9 +2191,6 @@ html, body, .feature-card, .food-card, .navbar, .modal-content, .footer, .stats-
     }
 }
 
-.scroll-indicator {
-    animation: wiggle 1s ease-in-out infinite;
-}
 
 @keyframes wiggle {
     0%, 100% { transform: translateX(-50%) rotate(0deg); }

--- a/index.html
+++ b/index.html
@@ -113,10 +113,10 @@
           </div>
         </div>
       </div>
-      <div class="scroll-indicator">
-        <i class="fas fa-chevron-down"></i>
-      </div>
     </section>
+    <div class="scroll-indicator">
+      <i class="fas fa-chevron-down"></i>
+    </div>
 
     <!-- Features Section -->
     <section id="features" class="features">

--- a/js/script.js
+++ b/js/script.js
@@ -505,13 +505,7 @@ handleFileSelect(file) {
         });
     }
 
-    setupSmoothScrolling() {
-        const scrollIndicator = document.querySelector('.scroll-indicator');
-        
-        scrollIndicator.addEventListener('click', () => {
-            document.getElementById('features').scrollIntoView({ behavior: 'smooth' });
-        });
-    }
+    
 
     setupResponsiveNav() {
         const hamburger = document.querySelector('.hamburger');
@@ -1061,3 +1055,14 @@ window.clearShareBiteCaches = async function() {
         console.log('[ShareBite] Sent SKIP_WAITING to service worker');
     }
 };
+
+document.addEventListener('DOMContentLoaded', () => {
+    const scrollIndicator = document.querySelector('.scroll-indicator');
+    if (scrollIndicator) {
+      scrollIndicator.addEventListener('click', () => {
+        document.getElementById('features').scrollIntoView({ behavior: 'smooth' });
+      });
+    }
+  });
+  
+  


### PR DESCRIPTION
…clickable and smoothly scrolls to the Features section. The indicator’s clickable area was previously blocked by overlapping elements (.hero-container and .hero::before), preventing user interaction.

Added CSS rules to ensure the .scroll-indicator has the highest z-index and proper pointer-events handling.

Disabled pointer interception from .hero-container and .hero::before which were overlapping the indicator.

Ensured consistent clickable area and smooth scrolling behavior even after page refresh.

Verified that the fix works across refreshes and does not interfere with other interactive elements (buttons, links, etc.) in the hero section.