### PR TITLE
fix: adding favicon in login and register page

### DIFF
--- a/login.html
+++ b/login.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/svg+xml" href="logo/logo.svg">
     <style>
         :root {
             --primary-green: #4CAF50;

--- a/register.html
+++ b/register.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/svg+xml" href="logo/logo.svg">
     <style>
         :root {
             --primary-green: #4CAF50;


### PR DESCRIPTION
fix: #85
adding favicon in login and register page
<img width="226" height="45" alt="image" src="https://github.com/user-attachments/assets/3dfce968-6a50-40c8-bd72-2113a5cd37a1" />
<img width="190" height="41" alt="image" src="https://github.com/user-attachments/assets/715d2305-e900-4751-8340-2200fc1a63dd" />
