### PR TITLE
Add the visibility to links in navbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2618,6 +2618,10 @@ body.dark-mode .divider-icon {
     box-shadow: 0 4px 20px rgba(255, 107, 53, 0.3);
 }
 
+body.dark-mode .nav-menu a{
+    color: var(--white);
+}
+
 /* --- Responsive --- */
 @media (max-width: 900px) {
   .contact-container {


### PR DESCRIPTION
I added the visibility to links in the Navbar in Dark mode.

<img width="1903" height="488" alt="Screenshot 2025-10-08 205054" src="https://github.com/user-attachments/assets/5f5c872d-db65-401a-b753-344d02934a31" />

Hi @angelabera please check and merge this PR with labels.
Thanks!