### PR TITLE
 Fix dark mode navbar color on scroll (add scrolled state; clean CSS)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -77,6 +77,12 @@ body {
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 }
 
+/* Navbar state when scrolled (light mode) */
+.navbar.scrolled {
+    background: rgba(255, 255, 255, 0.98);
+    box-shadow: var(--shadow-light);
+}
+
 .nav-container {
     max-width: 1200px;
     margin: 0 auto;
@@ -1615,6 +1621,12 @@ body {
     border-bottom: 1px solid #2a2a2a;
 }
 
+/* Navbar state when scrolled (dark mode) */
+:root.dark .navbar.scrolled {
+    background: rgba(18,18,18,0.95);
+    box-shadow: 0 2px 10px rgba(0,0,0,0.6);
+}
+
 :root.dark .nav-link { color: var(--medium-gray); }
 :root.dark .nav-link:hover { color: var(--primary-light); }
 
@@ -2975,5 +2987,4 @@ body.dark-mode .notification-bell:hover {
     margin: 0 1rem;
     font-size: 1.2rem;
   }
-}
 

--- a/js/foodlisting.js
+++ b/js/foodlisting.js
@@ -576,16 +576,17 @@ handleFileSelect(file) {
 
     setupScrollEffects() {
         // Navbar background on scroll
-        window.addEventListener('scroll', () => {
+        const handleScroll = () => {
             const navbar = document.querySelector('.navbar');
+            if (!navbar) return;
             if (window.scrollY > 50) {
-                navbar.style.background = 'rgba(255, 255, 255, 0.98)';
-                navbar.style.boxShadow = 'var(--shadow-light)';
+                navbar.classList.add('scrolled');
             } else {
-                navbar.style.background = 'rgba(255, 255, 255, 0.95)';
-                navbar.style.boxShadow = 'none';
+                navbar.classList.remove('scrolled');
             }
-        });
+        };
+        window.addEventListener('scroll', handleScroll);
+        handleScroll();
         
         // Animate elements on scroll
         this.setupScrollAnimations();

--- a/js/script.js
+++ b/js/script.js
@@ -602,16 +602,18 @@ handleFileSelect(file) {
 
     setupScrollEffects() {
         // Navbar background on scroll
-        window.addEventListener('scroll', () => {
+        const handleScroll = () => {
             const navbar = document.querySelector('.navbar');
+            if (!navbar) return;
             if (window.scrollY > 50) {
-                navbar.style.background = 'rgba(255, 255, 255, 0.98)';
-                navbar.style.boxShadow = 'var(--shadow-light)';
+                navbar.classList.add('scrolled');
             } else {
-                navbar.style.background = 'rgba(255, 255, 255, 0.95)';
-                navbar.style.boxShadow = 'none';
+                navbar.classList.remove('scrolled');
             }
-        });
+        };
+        window.addEventListener('scroll', handleScroll);
+        // Apply initial state in case page loads scrolled (anchor/hash navigation)
+        handleScroll();
         
         // Animate elements on scroll
         this.setupScrollAnimations();


### PR DESCRIPTION
Implemented a robust solution for the navbar color issue where in dark mode the bar turned light when scrolling. 
1) Added a semantic .navbar.scrolled class with separate light and dark mode styles instead of forcing inline light backgrounds.                2) Updated both [script.js] and [foodlisting.js] to toggle the class and apply initial state on load (handles direct anchor navigation).    3) Also removed a stray extra closing brace in [style.css] uncovered during the change. A later experimental body background refactor (adding --app-bg-light / --app-bg-dark) was reverted, so the only persistent change is the navbar scroll behavior and associated cleanup

<img width="1901" height="350" alt="image" src="https://github.com/user-attachments/assets/94eeb532-7b5e-424f-a2f7-d28b2e816864" />
