### PR TITLE
feat: Implement active navigation state with underline indicator

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -149,6 +149,24 @@ body {
     width: 100%;
 }
 
+.nav-link.active {
+    color: var(--primary-color) !important;
+    font-weight: 600 !important;
+}
+
+.nav-link.active::after {
+    width: 100% !important;
+    background: var(--primary-color) !important;
+}
+
+:root.dark .nav-link.active {
+    color: var(--primary-color) !important;
+}
+
+:root.dark .nav-link.active::after {
+    background: var(--primary-color) !important;
+}
+
 .user-actions {
     display: flex;
     align-items: center;

--- a/foodlisting.html
+++ b/foodlisting.html
@@ -25,11 +25,11 @@
                 <span>ShareBite</span>
             </div>
             <ul class="nav-menu">
-                <li><a href="index.html" class="nav-link">Home</a></li>
+                <li><a href="index.html#home" class="nav-link">Home</a></li>
                 <li><a href="index.html#features" class="nav-link">Features</a></li>
                 <li><a href="foodlisting.html" class="nav-link">Listings</a></li>
                 <li><a href="index.html#about" class="nav-link">About</a></li>
-                <li><a href="index.html#contact" class="nav-link">Contact</a></li>
+                <li><a href="index.html#contact-section" class="nav-link">Contact</a></li>
             </ul>
             <div class="user-actions">
                 <!-- Added dark mode toggle -->

--- a/js/foodlisting.js
+++ b/js/foodlisting.js
@@ -88,9 +88,14 @@ class ShareBiteFoodListing {
 
     setupNavigation() {
         const navLinks = document.querySelectorAll('.nav-link');
+        
+        // Set initial active state for current page
+        this.setInitialActiveNavLink();
+        
         navLinks.forEach(link => {
             link.addEventListener('click', (e) => {
                 const href = link.getAttribute('href');
+                
                 // If it's an anchor for current page, scroll smoothly
                 if (href && href.startsWith('#')) {
                     e.preventDefault();
@@ -98,15 +103,50 @@ class ShareBiteFoodListing {
                     const targetElement = document.getElementById(targetId);
                     if (targetElement) {
                         targetElement.scrollIntoView({ behavior: 'smooth' });
+                        setTimeout(() => this.setActiveNavLink(targetId), 500);
                     }
                 } else if (href && href.includes('.html#')) {
                     // If it's index.html#features or similar, navigate normally
                     // (let browser handle navigation)
                 } else if (href && href.endsWith('.html')) {
-                    // If it's a plain .html link, let browser handle navigation
+                    // If it's a plain .html link, set active state before navigation
+                    this.setActiveNavLink(href);
                 }
             });
         });
+    }
+
+    setInitialActiveNavLink() {
+        // Check if we're on the foodlisting page
+        if (window.location.pathname.includes('foodlisting.html')) {
+            this.setActiveNavLink('foodlisting.html');
+        } else if (window.location.pathname.includes('index.html') || window.location.pathname === '/') {
+            // Default to home for the main page
+            this.setActiveNavLink('home');
+        }
+    }
+
+    setActiveNavLink(targetId) {
+        const navLinks = document.querySelectorAll('.nav-link');
+        
+        // Remove active class from all links first
+        navLinks.forEach(link => link.classList.remove('active'));
+        
+        // Handle different types of links
+        let targetLink;
+        if (targetId === 'home' || targetId === 'index.html') {
+            targetLink = document.querySelector('.nav-link[href="index.html"]');
+        } else if (targetId === 'foodlisting.html') {
+            targetLink = document.querySelector('.nav-link[href="foodlisting.html"]');
+        } else if (targetId.startsWith('#')) {
+            targetLink = document.querySelector(`.nav-link[href="${targetId}"]`);
+        } else {
+            targetLink = document.querySelector(`.nav-link[href="#${targetId}"]`);
+        }
+        
+        if (targetLink) {
+            targetLink.classList.add('active');
+        }
     }
 
     setupRoleSwitch() {

--- a/js/script.js
+++ b/js/script.js
@@ -94,19 +94,75 @@ class ShareBite {
 
     setupNavigation() {
         const navLinks = document.querySelectorAll('.nav-link');
+        
+        // Set initial active state for HOME or current page
+        this.setInitialActiveNavLink();
+        
         navLinks.forEach(link => {
             link.addEventListener('click', (e) => {
                 const href = link.getAttribute('href');
-                // Ignore .html links
-                if (href && href.endsWith('.html')) return;
+                
+                // For .html links, let them navigate normally but set active state
+                if (href && href.endsWith('.html')) {
+                    this.setActiveNavLink(href);
+                    return;
+                }
+                
+                // For anchor links, prevent default and scroll smoothly
                 e.preventDefault();
                 const targetId = href.substring(1);
                 const targetElement = document.getElementById(targetId);
                 if (targetElement) {
                     targetElement.scrollIntoView({ behavior: 'smooth' });
+                    // Update active state after scrolling
+                    setTimeout(() => this.setActiveNavLink(targetId), 500);
                 }
             });
         });
+        
+        // Listen for hash changes (browser back/forward buttons or direct hash changes)
+        window.addEventListener('hashchange', () => {
+            this.setInitialActiveNavLink();
+        });
+    }
+
+    setInitialActiveNavLink() {
+        // Check if we're on the foodlisting page
+        if (window.location.pathname.includes('foodlisting.html')) {
+            this.setActiveNavLink('foodlisting.html');
+        } else {
+            // Check if there's a hash in the URL (e.g., #about, #features)
+            const hash = window.location.hash;
+            if (hash) {
+                // Remove the # and set active based on the hash
+                const targetId = hash.substring(1);
+                this.setActiveNavLink(targetId);
+            } else {
+                // Default to home if no hash
+                this.setActiveNavLink('home');
+            }
+        }
+    }
+
+    setActiveNavLink(targetId) {
+        const navLinks = document.querySelectorAll('.nav-link');
+        
+        // Remove active class from all links first
+        navLinks.forEach(link => link.classList.remove('active'));
+        
+        // Handle different types of links
+        let targetLink;
+        if (targetId === 'home') {
+            targetLink = document.querySelector('.nav-link[href="#home"]');
+        } else if (targetId === 'foodlisting.html') {
+            targetLink = document.querySelector('.nav-link[href="foodlisting.html"]');
+        } else {
+            targetLink = document.querySelector(`.nav-link[href="#${targetId}"]`);
+        }
+        
+        if (targetLink) {
+            targetLink.classList.add('active');
+        }
     }
 
     setupRoleSwitch() {


### PR DESCRIPTION
Added dynamic navigation underline that highlights the current page/section:

**Features:**
- Active nav item displays visual underline indicator
- Only one nav item is active at a time
- Automatic detection of current page on load
- Supports both anchor links (#home, #features) and page navigation (foodlisting.html)
- Browser back/forward button support via hashchange listener

**Changes:**
- script.js: Added setInitialActiveNavLink() and setActiveNavLink() methods
  * Detects URL hash fragments to set correct active state
  * Updates active state on page load and navigation clicks
  * Listens for hashchange events for browser navigation

- foodlisting.js: Implemented same active navigation logic for listings page
  * Ensures "Listings" stays underlined when on foodlisting.html
  * Handles navigation back to index.html sections

- style.css: Added .nav-link.active styles
  * Underline animation using ::after pseudo-element
  * Color change to primary color
  * Font weight increase for better visibility
  * Dark mode support

- foodlisting.html: Fixed navigation links
  * Updated links to include proper hash fragments (index.html#home, etc.)
  * Fixed contact link to use correct section ID (#contact-section)

**User Experience:**
- HOME underlined by default on index.html
- LISTINGS underlined by default on foodlisting.html
- Active section updates when clicking nav items or using browser navigation
- Smooth scrolling maintained for same-page navigation


Close #250 