### PR TITLE
Fix: Make footer responsive for mobile screens fixed isuue #275

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1752,6 +1752,34 @@ body.dark .profile-menu-item:hover {
 .footer-section ul li a:hover::after {
     width: 100%; /* Expand underline on hover */
 }
+@media (max-width: 992px) {
+    .footer-content {
+        grid-template-columns: 1fr 1fr; 
+        gap: 1.5rem;
+    }
+}
+
+@media (max-width: 768px) {
+    .footer-content {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+        text-align: center;
+    }
+
+    .footer-logo {
+        justify-content: center;
+    }
+
+    .footer-section p {
+        text-align: center;
+    }
+
+    .social-links {
+        justify-content: center;
+        display: flex;
+        margin-top: 0.5rem;
+    }
+}
 
 
 /* Social links */


### PR DESCRIPTION
# Make Footer Responsive for Mobile Screens

## Description
This PR improves the responsiveness of the **ShareBite footer** across different screen sizes, ensuring a better mobile and tablet experience.



## Screenshots
- Before
<img width="620" height="977" alt="Screenshot 2025-10-17 172337" src="https://github.com/user-attachments/assets/c299c234-e7bf-4d52-8d73-a6789786398c" />
- After 
<img width="626" height="972" alt="Screenshot 2025-10-17 172407" src="https://github.com/user-attachments/assets/18f4cb43-16e5-4ce6-b41b-0b1a2a8746e1" />



## Impact
- Improved mobile and tablet user experience  
- Footer elements are now properly aligned and readable on all devices  
- No impact on existing desktop layout or functionality

## Notes
- Only CSS/layout changes, no functionality changes  
- Fully compatible with existing site design
- Fixed issue #275 
