### PR TITLE
Fix: prevent flicker when copying contact; stop propagation and improve clipboard fallback 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,18 @@ coverage/
 
 # VSCode
 .vscode/
+
+# Ignore node_modules in subfolders explicitly
+/backend/node_modules/
+/frontend/node_modules/
+
+# Environment files - ignore any .env files and variants
+.env*
+# Explicitly ignore backend local env too (we created backend/src/.env during testing)
+/backend/src/.env
+
+# Editor/OS temp files
+.idea/
+.venv/
+*.tmp
+*.temp

--- a/frontend/js/foodlisting.js
+++ b/frontend/js/foodlisting.js
@@ -1,218 +1,235 @@
 // ShareBite JavaScript - Interactive Food Waste Reduction Platform
 
 class ShareBiteFoodListing {
-    constructor() {
-        this.currentRole = 'donor';
-        this.foodListings = [];
-        this.filteredListings = [];
-        this.currentFilter = 'all';
-        this.claimedItems = this.loadClaimedItems();
-        this.notifications = this.loadNotifications();
-        
-        this.init();
-        this.initTheme(); // add theme initialization after base init
-    }
+  constructor() {
+    this.currentRole = "donor";
+    this.foodListings = [];
+    this.filteredListings = [];
+    this.currentFilter = "all";
+    this.claimedItems = this.loadClaimedItems();
+    this.notifications = this.loadNotifications();
 
-    init() {
-        this.setupEventListeners();
-        this.generateSampleListings();
-        this.renderFoodListings();
-        this.setupNotificationSystem();
-        this.updateNotificationDisplay();
-        this.startAnimations();
-        this.hideLoadingOverlay();
-    }
+    this.init();
+    this.initTheme(); // add theme initialization after base init
+  }
 
-    initTheme() {
-        const stored = localStorage.getItem('sharebite-theme');
-        const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-        const theme = stored || (prefersDark ? 'dark' : 'light');
-        this.applyTheme(theme);
-        this.setupThemeToggle();
-    }
+  init() {
+    this.setupEventListeners();
+    this.generateSampleListings();
+    this.renderFoodListings();
+    this.setupNotificationSystem();
+    this.updateNotificationDisplay();
+    this.startAnimations();
+    this.hideLoadingOverlay();
+  }
 
-    setupThemeToggle() {
-        const btn = document.getElementById('themeToggle');
-        if (!btn) return;
-        btn.addEventListener('click', () => {
-            const newTheme = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
-            this.applyTheme(newTheme);
-            localStorage.setItem('sharebite-theme', newTheme);
-        });
-    }
+  initTheme() {
+    const stored = localStorage.getItem("sharebite-theme");
+    const prefersDark =
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const theme = stored || (prefersDark ? "dark" : "light");
+    this.applyTheme(theme);
+    this.setupThemeToggle();
+  }
 
-    applyTheme(theme) {
-        const root = document.documentElement;
-        if (theme === 'dark') {
-            root.classList.add('dark');
-            const icon = document.querySelector('#themeToggle i');
-            if (icon) { icon.classList.remove('fa-moon'); icon.classList.add('fa-sun'); }
-        } else {
-            root.classList.remove('dark');
-            const icon = document.querySelector('#themeToggle i');
-            if (icon) { icon.classList.remove('fa-sun'); icon.classList.add('fa-moon'); }
+  setupThemeToggle() {
+    const btn = document.getElementById("themeToggle");
+    if (!btn) return;
+    btn.addEventListener("click", () => {
+      const newTheme = document.documentElement.classList.contains("dark")
+        ? "light"
+        : "dark";
+      this.applyTheme(newTheme);
+      localStorage.setItem("sharebite-theme", newTheme);
+    });
+  }
+
+  applyTheme(theme) {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+      const icon = document.querySelector("#themeToggle i");
+      if (icon) {
+        icon.classList.remove("fa-moon");
+        icon.classList.add("fa-sun");
+      }
+    } else {
+      root.classList.remove("dark");
+      const icon = document.querySelector("#themeToggle i");
+      if (icon) {
+        icon.classList.remove("fa-sun");
+        icon.classList.add("fa-moon");
+      }
+    }
+  }
+
+  setupEventListeners() {
+    // Navigation
+    this.setupNavigation();
+
+    // Role switching
+    this.setupRoleSwitch();
+
+    // Modal functionality
+    this.setupModal();
+
+    // Form handling
+    this.setupFormHandling();
+
+    // Date input confirmation functionality
+    this.setupDateInputConfirmation();
+
+    // Time input confirmation functionality
+    this.setupTimeInputConfirmation();
+
+    // Filtering and search
+    this.setupFilteringAndSearch();
+
+    // Responsive navigation
+    this.setupResponsiveNav();
+
+    // Statistics counter animation
+    this.setupStatsAnimation();
+
+    // Scroll effects
+    this.setupScrollEffects();
+  }
+
+  setupNavigation() {
+    const navLinks = document.querySelectorAll(".nav-link");
+    navLinks.forEach((link) => {
+      link.addEventListener("click", (e) => {
+        const href = link.getAttribute("href");
+        // If it's an anchor for current page, scroll smoothly
+        if (href && href.startsWith("#")) {
+          e.preventDefault();
+          const targetId = href.substring(1);
+          const targetElement = document.getElementById(targetId);
+          if (targetElement) {
+            targetElement.scrollIntoView({ behavior: "smooth" });
+          }
+        } else if (href && href.includes(".html#")) {
+          // If it's index.html#features or similar, navigate normally
+          // (let browser handle navigation)
+        } else if (href && href.endsWith(".html")) {
+          // If it's a plain .html link, let browser handle navigation
         }
+      });
+    });
+  }
+
+  setupRoleSwitch() {
+    const roleSwitch = document.getElementById("roleSwitch");
+    const currentRoleSpan = document.getElementById("currentRole");
+
+    roleSwitch.addEventListener("click", () => {
+      this.currentRole = this.currentRole === "donor" ? "collector" : "donor";
+      currentRoleSpan.textContent =
+        this.currentRole.charAt(0).toUpperCase() + this.currentRole.slice(1);
+
+      // Update UI based on role
+      this.updateUIForRole();
+    });
+  }
+
+  updateUIForRole() {
+    const donateBtn = document.getElementById("donateFood");
+    const findBtn = document.getElementById("findFood");
+    const addListingBtn = document.getElementById("addListingBtn");
+    const notificationBell = document.getElementById("notificationBell");
+
+    if (this.currentRole === "collector") {
+      if (donateBtn)
+        donateBtn.innerHTML = '<i class="fas fa-search"></i> Find Food';
+      if (findBtn)
+        findBtn.innerHTML = '<i class="fas fa-heart"></i> Help Others';
+      if (addListingBtn) addListingBtn.style.display = "none";
+
+      // Show notification bell for collectors
+      if (notificationBell) {
+        notificationBell.style.display = "block";
+      }
+    } else {
+      if (donateBtn)
+        donateBtn.innerHTML = '<i class="fas fa-heart"></i> Donate Food';
+      if (findBtn)
+        findBtn.innerHTML = '<i class="fas fa-search"></i> Find Food';
+      if (addListingBtn) addListingBtn.style.display = "flex";
+
+      // Hide notification bell for donors (unless they have notifications)
+      if (notificationBell && this.notifications.length === 0) {
+        notificationBell.style.display = "none";
+      }
     }
 
-    setupEventListeners() {
-        // Navigation
-        this.setupNavigation();
-        
-        // Role switching
-        this.setupRoleSwitch();
-        
-        // Modal functionality
-        this.setupModal();
-        
-        // Form handling
-        this.setupFormHandling();
-        
-        // Date input confirmation functionality
-        this.setupDateInputConfirmation();
-        
-        // Time input confirmation functionality
-        this.setupTimeInputConfirmation();
-        
-        // Filtering and search
-        this.setupFilteringAndSearch();
-        
-        // Responsive navigation
-        this.setupResponsiveNav();
-        
-        // Statistics counter animation
-        this.setupStatsAnimation();
-        
-        // Scroll effects
-        this.setupScrollEffects();
-    }
+    // Re-render food listings to update claim button states
+    this.renderFoodListings();
+  }
 
-    setupNavigation() {
-        const navLinks = document.querySelectorAll('.nav-link');
-        navLinks.forEach(link => {
-            link.addEventListener('click', (e) => {
-                const href = link.getAttribute('href');
-                // If it's an anchor for current page, scroll smoothly
-                if (href && href.startsWith('#')) {
-                    e.preventDefault();
-                    const targetId = href.substring(1);
-                    const targetElement = document.getElementById(targetId);
-                    if (targetElement) {
-                        targetElement.scrollIntoView({ behavior: 'smooth' });
-                    }
-                } else if (href && href.includes('.html#')) {
-                    // If it's index.html#features or similar, navigate normally
-                    // (let browser handle navigation)
-                } else if (href && href.endsWith('.html')) {
-                    // If it's a plain .html link, let browser handle navigation
-                }
-            });
-        });
-    }
-
-    setupRoleSwitch() {
-        const roleSwitch = document.getElementById('roleSwitch');
-        const currentRoleSpan = document.getElementById('currentRole');
-        
-        roleSwitch.addEventListener('click', () => {
-            this.currentRole = this.currentRole === 'donor' ? 'collector' : 'donor';
-            currentRoleSpan.textContent = this.currentRole.charAt(0).toUpperCase() + this.currentRole.slice(1);
-            
-            // Update UI based on role
-            this.updateUIForRole();
-        });
-    }
-
-    updateUIForRole() {
-        const donateBtn = document.getElementById('donateFood');
-        const findBtn = document.getElementById('findFood');
-        const addListingBtn = document.getElementById('addListingBtn');
-        const notificationBell = document.getElementById('notificationBell');
-        
-        if (this.currentRole === 'collector') {
-            if (donateBtn) donateBtn.innerHTML = '<i class="fas fa-search"></i> Find Food';
-            if (findBtn) findBtn.innerHTML = '<i class="fas fa-heart"></i> Help Others';
-            if (addListingBtn) addListingBtn.style.display = 'none';
-            
-            // Show notification bell for collectors
-            if (notificationBell) {
-                notificationBell.style.display = 'block';
-            }
-        } else {
-            if (donateBtn) donateBtn.innerHTML = '<i class="fas fa-heart"></i> Donate Food';
-            if (findBtn) findBtn.innerHTML = '<i class="fas fa-search"></i> Find Food';
-            if (addListingBtn) addListingBtn.style.display = 'flex';
-            
-            // Hide notification bell for donors (unless they have notifications)
-            if (notificationBell && this.notifications.length === 0) {
-                notificationBell.style.display = 'none';
-            }
-        }
-        
-        // Re-render food listings to update claim button states
-        this.renderFoodListings();
-    }
-
-   setupModal() {
-    const modal = document.getElementById('addListingModal');
-    const addListingBtn = document.getElementById('addListingBtn');
-    const closeModalBtn = document.querySelector('.close-modal');
-    const cancelBtn = document.getElementById('cancelForm');
+  setupModal() {
+    const modal = document.getElementById("addListingModal");
+    const addListingBtn = document.getElementById("addListingBtn");
+    const closeModalBtn = document.querySelector(".close-modal");
+    const cancelBtn = document.getElementById("cancelForm");
 
     this.currentStep = 1;
     this.totalSteps = 3;
 
-    addListingBtn.addEventListener('click', () => {
-        modal.style.display = 'block';
-        document.body.style.overflow = 'hidden';
-        this.resetFormSteps();
+    addListingBtn.addEventListener("click", () => {
+      modal.style.display = "block";
+      document.body.style.overflow = "hidden";
+      this.resetFormSteps();
     });
 
     const closeModal = () => {
-        modal.style.display = 'none';
-        document.body.style.overflow = 'auto';
-        this.resetForm();
-        this.resetFormSteps();
+      modal.style.display = "none";
+      document.body.style.overflow = "auto";
+      this.resetForm();
+      this.resetFormSteps();
     };
 
-    closeModalBtn.addEventListener('click', closeModal);
-    cancelBtn.addEventListener('click', closeModal);
-    
-    modal.addEventListener('click', (e) => {
-        if (e.target === modal) {
-            closeModal();
-        }
+    closeModalBtn.addEventListener("click", closeModal);
+    cancelBtn.addEventListener("click", closeModal);
+
+    modal.addEventListener("click", (e) => {
+      if (e.target === modal) {
+        closeModal();
+      }
     });
 
     this.setupFileUpload();
     this.setupFormNavigation();
-}
+  }
 
-setupFormNavigation() {
-    const nextBtn = document.getElementById('nextStep');
-    const prevBtn = document.getElementById('prevStep');
-    const submitBtn = document.getElementById('submitForm');
+  setupFormNavigation() {
+    const nextBtn = document.getElementById("nextStep");
+    const prevBtn = document.getElementById("prevStep");
+    const submitBtn = document.getElementById("submitForm");
 
-    nextBtn.addEventListener('click', () => {
-        if (this.validateCurrentStep()) {
-            this.goToStep(this.currentStep + 1);
-        }
+    nextBtn.addEventListener("click", () => {
+      if (this.validateCurrentStep()) {
+        this.goToStep(this.currentStep + 1);
+      }
     });
 
-    prevBtn.addEventListener('click', () => {
-        this.goToStep(this.currentStep - 1);
+    prevBtn.addEventListener("click", () => {
+      this.goToStep(this.currentStep - 1);
     });
-}
+  }
 
-goToStep(stepNumber) {
+  goToStep(stepNumber) {
     if (stepNumber < 1 || stepNumber > this.totalSteps) return;
 
-    document.querySelectorAll('.form-step').forEach(step => {
-        step.classList.remove('active');
+    document.querySelectorAll(".form-step").forEach((step) => {
+      step.classList.remove("active");
     });
 
-    const newStep = document.querySelector(`.form-step[data-step="${stepNumber}"]`);
+    const newStep = document.querySelector(
+      `.form-step[data-step="${stepNumber}"]`
+    );
     if (newStep) {
-        newStep.classList.add('active');
+      newStep.classList.add("active");
     }
 
     this.updateProgress(stepNumber);
@@ -220,260 +237,290 @@ goToStep(stepNumber) {
     this.updateNavigationButtons(stepNumber);
 
     this.currentStep = stepNumber;
-}
+  }
 
-updateProgress(stepNumber) {
-    const steps = document.querySelectorAll('.progress-step');
-    
+  updateProgress(stepNumber) {
+    const steps = document.querySelectorAll(".progress-step");
+
     steps.forEach((step, index) => {
-        const stepNum = index + 1;
-        
-        if (stepNum < stepNumber) {
-            step.classList.add('completed');
-            step.classList.remove('active');
-        } else if (stepNum === stepNumber) {
-            step.classList.add('active');
-            step.classList.remove('completed');
-        } else {
-            step.classList.remove('active', 'completed');
-        }
+      const stepNum = index + 1;
+
+      if (stepNum < stepNumber) {
+        step.classList.add("completed");
+        step.classList.remove("active");
+      } else if (stepNum === stepNumber) {
+        step.classList.add("active");
+        step.classList.remove("completed");
+      } else {
+        step.classList.remove("active", "completed");
+      }
     });
-}
+  }
 
-updateNavigationButtons(stepNumber) {
-    const nextBtn = document.getElementById('nextStep');
-    const prevBtn = document.getElementById('prevStep');
-    const submitBtn = document.getElementById('submitForm');
+  updateNavigationButtons(stepNumber) {
+    const nextBtn = document.getElementById("nextStep");
+    const prevBtn = document.getElementById("prevStep");
+    const submitBtn = document.getElementById("submitForm");
 
-    prevBtn.style.display = stepNumber === 1 ? 'none' : 'flex';
-    nextBtn.style.display = stepNumber === this.totalSteps ? 'none' : 'flex';
-    submitBtn.style.display = stepNumber === this.totalSteps ? 'flex' : 'none';
-}
+    prevBtn.style.display = stepNumber === 1 ? "none" : "flex";
+    nextBtn.style.display = stepNumber === this.totalSteps ? "none" : "flex";
+    submitBtn.style.display = stepNumber === this.totalSteps ? "flex" : "none";
+  }
 
-validateCurrentStep() {
-    const currentStepEl = document.querySelector(`.form-step[data-step="${this.currentStep}"]`);
-    const requiredInputs = currentStepEl.querySelectorAll('[required]');
-    
+  validateCurrentStep() {
+    const currentStepEl = document.querySelector(
+      `.form-step[data-step="${this.currentStep}"]`
+    );
+    const requiredInputs = currentStepEl.querySelectorAll("[required]");
+
     for (let input of requiredInputs) {
-        if (!input.value.trim()) {
-            input.focus();
-            this.showToast(`Please fill in the required field: ${input.previousElementSibling.textContent}`, 'error');
-            return false;
-        }
-        
-        // Special validation for contact information
-        if (input.id === 'contact') {
-            if (!this.validateContactInfo(input.value.trim())) {
-                input.focus();
-                this.showToast('Please enter a valid email address or phone number', 'error');
-                return false;
-            }
-        }
-    }
-    
-    return true;
-}
+      if (!input.value.trim()) {
+        input.focus();
+        this.showToast(
+          `Please fill in the required field: ${input.previousElementSibling.textContent}`,
+          "error"
+        );
+        return false;
+      }
 
-// Validate contact information (email or phone number)
-validateContactInfo(contact) {
+      // Special validation for contact information
+      if (input.id === "contact") {
+        if (!this.validateContactInfo(input.value.trim())) {
+          input.focus();
+          this.showToast(
+            "Please enter a valid email address or phone number",
+            "error"
+          );
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  // Validate contact information (email or phone number)
+  validateContactInfo(contact) {
     // Email regex pattern
     const emailPattern = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
-    
+
     // Phone number regex pattern (supports various formats)
     const phonePattern = /^[\+]?[1-9]?[\d\s\-\(\)]{7,15}$/;
-    
+
     // Remove spaces and common characters for phone validation
-    const cleanedContact = contact.replace(/[\s\-\(\)]/g, '');
-    
+    const cleanedContact = contact.replace(/[\s\-\(\)]/g, "");
+
     // Check if it's a valid email
     if (emailPattern.test(contact)) {
-        return true;
+      return true;
     }
-    
-    // Check if it's a valid phone number
-    if (phonePattern.test(contact) && cleanedContact.length >= 7 && cleanedContact.length <= 15) {
-        return true;
-    }
-    
-    return false;
-}
 
-resetFormSteps() {
+    // Check if it's a valid phone number
+    if (
+      phonePattern.test(contact) &&
+      cleanedContact.length >= 7 &&
+      cleanedContact.length <= 15
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  resetFormSteps() {
     this.currentStep = 1;
     this.goToStep(1);
-}
+  }
 
-setupFileUpload() {
-    const fileInput = document.getElementById('photo');
-    const uploadArea = document.getElementById('photoUpload');
-    const imagePreview = document.getElementById('imagePreview');
+  setupFileUpload() {
+    const fileInput = document.getElementById("photo");
+    const uploadArea = document.getElementById("photoUpload");
+    const imagePreview = document.getElementById("imagePreview");
 
-    uploadArea.addEventListener('click', () => {
-        fileInput.click();
+    uploadArea.addEventListener("click", () => {
+      fileInput.click();
     });
 
-    uploadArea.addEventListener('dragover', (e) => {
-        e.preventDefault();
-        uploadArea.classList.add('drag-over');
+    uploadArea.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      uploadArea.classList.add("drag-over");
     });
 
-    uploadArea.addEventListener('dragleave', (e) => {
-        e.preventDefault();
-        uploadArea.classList.remove('drag-over');
+    uploadArea.addEventListener("dragleave", (e) => {
+      e.preventDefault();
+      uploadArea.classList.remove("drag-over");
     });
 
-    uploadArea.addEventListener('drop', (e) => {
-        e.preventDefault();
-        uploadArea.classList.remove('drag-over');
-        const files = e.dataTransfer.files;
-        if (files.length > 0 && files[0].type.startsWith('image/')) {
-            fileInput.files = files;
-            this.handleFileSelect(files[0]);
-        } else {
-            this.showToast('Please upload a valid image file', 'error');
-        }
+    uploadArea.addEventListener("drop", (e) => {
+      e.preventDefault();
+      uploadArea.classList.remove("drag-over");
+      const files = e.dataTransfer.files;
+      if (files.length > 0 && files[0].type.startsWith("image/")) {
+        fileInput.files = files;
+        this.handleFileSelect(files[0]);
+      } else {
+        this.showToast("Please upload a valid image file", "error");
+      }
     });
 
-    fileInput.addEventListener('change', (e) => {
-        if (e.target.files.length > 0) {
-            this.handleFileSelect(e.target.files[0]);
-        }
+    fileInput.addEventListener("change", (e) => {
+      if (e.target.files.length > 0) {
+        this.handleFileSelect(e.target.files[0]);
+      }
     });
-}
+  }
 
-handleFileSelect(file) {
-    const imagePreview = document.getElementById('imagePreview');
-    const uploadArea = document.getElementById('photoUpload');
-    
-    if (!file.type.startsWith('image/')) {
-        this.showToast('Please select an image file', 'error');
-        return;
+  handleFileSelect(file) {
+    const imagePreview = document.getElementById("imagePreview");
+    const uploadArea = document.getElementById("photoUpload");
+
+    if (!file.type.startsWith("image/")) {
+      this.showToast("Please select an image file", "error");
+      return;
     }
 
     if (file.size > 5 * 1024 * 1024) {
-        this.showToast('Image size should be less than 5MB', 'error');
-        return;
+      this.showToast("Image size should be less than 5MB", "error");
+      return;
     }
 
     const reader = new FileReader();
     reader.onload = (e) => {
-        imagePreview.innerHTML = `
+      imagePreview.innerHTML = `
             <img src="${e.target.result}" alt="Food preview">
             <button type="button" class="remove-image">
                 <i class="fas fa-times"></i>
             </button>
         `;
-        imagePreview.classList.add('active');
-        uploadArea.style.display = 'none';
+      imagePreview.classList.add("active");
+      uploadArea.style.display = "none";
 
-        // Add remove functionality
-        const removeBtn = imagePreview.querySelector('.remove-image');
-        removeBtn.addEventListener('click', () => {
-            imagePreview.innerHTML = '';
-            imagePreview.classList.remove('active');
-            uploadArea.style.display = 'block';
-            document.getElementById('photo').value = '';
-        });
+      // Add remove functionality
+      const removeBtn = imagePreview.querySelector(".remove-image");
+      removeBtn.addEventListener("click", () => {
+        imagePreview.innerHTML = "";
+        imagePreview.classList.remove("active");
+        uploadArea.style.display = "block";
+        document.getElementById("photo").value = "";
+      });
     };
     reader.readAsDataURL(file);
-}
+  }
 
+  setupFormHandling() {
+    const form = document.getElementById("listingForm");
 
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      this.handleFormSubmission();
+    });
 
-    setupFormHandling() {
-        const form = document.getElementById('listingForm');
-        
-        form.addEventListener('submit', (e) => {
-            e.preventDefault();
-            this.handleFormSubmission();
-        });
+    const freshUntilInput = document.getElementById("freshUntil");
+    const now = new Date();
+    now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
+    freshUntilInput.min = now.toISOString().slice(0, 16);
+  }
 
-        const freshUntilInput = document.getElementById('freshUntil');
-        const now = new Date();
-        now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
-        freshUntilInput.min = now.toISOString().slice(0, 16);
+  handleFormSubmission() {
+    const formData = this.getFormData();
+
+    if (this.validateFormData(formData)) {
+      this.addNewListing(formData);
+      this.showSuccessMessage();
+      this.closeModalAndReset();
+    }
+  }
+
+  getFormData() {
+    return {
+      id: Date.now(),
+      foodType: document.getElementById("foodType").value,
+      quantity: document.getElementById("quantity").value,
+      category: document.getElementById("category").value,
+      description: document.getElementById("description").value,
+      freshUntil: document.getElementById("freshUntil").value,
+      pickupTime: document.getElementById("pickupTime").value,
+      location: document.getElementById("location").value,
+      contact: document.getElementById("contact").value,
+      photo: document.getElementById("photo").files[0],
+      createdAt: new Date(),
+      donor: "Current User",
+    };
+  }
+
+  validateFormData(data) {
+    const requiredFields = [
+      "foodType",
+      "quantity",
+      "category",
+      "freshUntil",
+      "pickupTime",
+      "location",
+      "contact",
+    ];
+
+    for (let field of requiredFields) {
+      if (!data[field] || data[field].trim() === "") {
+        this.showErrorMessage(
+          `Please fill in the ${field
+            .replace(/([A-Z])/g, " $1")
+            .toLowerCase()}.`
+        );
+        return false;
+      }
     }
 
-    handleFormSubmission() {
-        const formData = this.getFormData();
-        
-        if (this.validateFormData(formData)) {
-            this.addNewListing(formData);
-            this.showSuccessMessage();
-            this.closeModalAndReset();
-        }
+    const freshDate = new Date(data.freshUntil);
+    if (freshDate <= new Date()) {
+      this.showErrorMessage("Fresh until date must be in the future.");
+      return false;
     }
 
-    getFormData() {
-        return {
-            id: Date.now(),
-            foodType: document.getElementById('foodType').value,
-            quantity: document.getElementById('quantity').value,
-            category: document.getElementById('category').value,
-            description: document.getElementById('description').value,
-            freshUntil: document.getElementById('freshUntil').value,
-            pickupTime: document.getElementById('pickupTime').value,
-            location: document.getElementById('location').value,
-            contact: document.getElementById('contact').value,
-            photo: document.getElementById('photo').files[0],
-            createdAt: new Date(),
-            donor: 'Current User'
-        };
+    // Validate contact information
+    if (!this.validateContactInfo(data.contact)) {
+      this.showErrorMessage(
+        "Please enter a valid email address or phone number for contact information."
+      );
+      return false;
     }
 
-    validateFormData(data) {
-        const requiredFields = ['foodType', 'quantity', 'category', 'freshUntil', 'pickupTime', 'location', 'contact'];
-        
-        for (let field of requiredFields) {
-            if (!data[field] || data[field].trim() === '') {
-                this.showErrorMessage(`Please fill in the ${field.replace(/([A-Z])/g, ' $1').toLowerCase()}.`);
-                return false;
-            }
-        }
-        
-        const freshDate = new Date(data.freshUntil);
-        if (freshDate <= new Date()) {
-            this.showErrorMessage('Fresh until date must be in the future.');
-            return false;
-        }
-        
-        // Validate contact information
-        if (!this.validateContactInfo(data.contact)) {
-            this.showErrorMessage('Please enter a valid email address or phone number for contact information.');
-            return false;
-        }
-        
-        return true;
-    }
+    return true;
+  }
 
-    addNewListing(data) {
-        this.foodListings.unshift(data);
-        this.filterListings();
-        this.renderFoodListings();
-    }
+  addNewListing(data) {
+    this.foodListings.unshift(data);
+    this.filterListings();
+    this.renderFoodListings();
+  }
 
-    showSuccessMessage() {
-        this.showToast('Food listing added successfully!', 'success');
-    }
+  showSuccessMessage() {
+    this.showToast("Food listing added successfully!", "success");
+  }
 
-    showErrorMessage(message) {
-        this.showToast(message, 'error');
-    }
+  showErrorMessage(message) {
+    this.showToast(message, "error");
+  }
 
-    showToast(message, type) {
-        const toast = document.createElement('div');
-        toast.className = `toast toast-${type}`;
-        toast.innerHTML = `
-            <i class="fas fa-${type === 'success' ? 'check-circle' : 'exclamation-circle'}"></i>
+  showToast(message, type) {
+    const toast = document.createElement("div");
+    toast.className = `toast toast-${type}`;
+    toast.innerHTML = `
+            <i class="fas fa-${
+              type === "success" ? "check-circle" : "exclamation-circle"
+            }"></i>
             <span>${message}</span>
         `;
-        
-        // Add toast styles
-        toast.style.cssText = `
+
+    // Add toast styles
+    toast.style.cssText = `
             position: fixed;
             top: 100px;
             right: 20px;
-            background: ${type === 'success' ? 'var(--primary-color)' : 'var(--secondary-color)'};
+            background: ${
+              type === "success"
+                ? "var(--primary-color)"
+                : "var(--secondary-color)"
+            };
             color: white;
             padding: 1rem 1.5rem;
             border-radius: var(--border-radius);
@@ -484,518 +531,569 @@ handleFileSelect(file) {
             animation: slideInRight 0.3s ease, fadeOut 0.3s ease 2.7s forwards;
             box-shadow: var(--shadow-heavy);
         `;
-        
-        document.body.appendChild(toast);
-        
-        setTimeout(() => {
-            if (toast.parentNode) {
-                toast.parentNode.removeChild(toast);
-            }
-        }, 3000);
-    }
 
-    closeModalAndReset() {
-        document.getElementById('addListingModal').style.display = 'none';
-        document.body.style.overflow = 'auto';
-        this.resetForm();
-    }
+    document.body.appendChild(toast);
 
-    resetForm() {
-        document.getElementById('listingForm').reset();
-        document.getElementById('photoUpload').innerHTML = `
+    setTimeout(() => {
+      if (toast.parentNode) {
+        toast.parentNode.removeChild(toast);
+      }
+    }, 3000);
+  }
+
+  closeModalAndReset() {
+    document.getElementById("addListingModal").style.display = "none";
+    document.body.style.overflow = "auto";
+    this.resetForm();
+  }
+
+  resetForm() {
+    document.getElementById("listingForm").reset();
+    document.getElementById("photoUpload").innerHTML = `
             <i class="fas fa-cloud-upload-alt"></i>
             <span>Click to upload or drag and drop</span>
         `;
-        
-        // Reset minimum date
-        const freshUntilInput = document.getElementById('freshUntil');
-        const now = new Date();
-        now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
-        freshUntilInput.min = now.toISOString().slice(0, 16);
-    }
 
+    // Reset minimum date
+    const freshUntilInput = document.getElementById("freshUntil");
+    const now = new Date();
+    now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
+    freshUntilInput.min = now.toISOString().slice(0, 16);
+  }
 
-    setupFilteringAndSearch() {
+  setupFilteringAndSearch() {
     // --- Existing Category Filter Logic ---
-    const filterBtns = document.querySelectorAll('.filter-btn');
-    filterBtns.forEach(btn => {
-        btn.addEventListener('click', () => {
-            filterBtns.forEach(b => b.classList.remove('active'));
-            btn.classList.add('active');
-            this.currentFilter = btn.getAttribute('data-filter');
-            this.filterListings();
-            this.renderFoodListings();
-        });
+    const filterBtns = document.querySelectorAll(".filter-btn");
+    filterBtns.forEach((btn) => {
+      btn.addEventListener("click", () => {
+        filterBtns.forEach((b) => b.classList.remove("active"));
+        btn.classList.add("active");
+        this.currentFilter = btn.getAttribute("data-filter");
+        this.filterListings();
+        this.renderFoodListings();
+      });
     });
 
     // --- Existing Search Input Logic ---
-    const searchInput = document.querySelector('.search-box input');
+    const searchInput = document.querySelector(".search-box input");
     let searchTimeout;
-    searchInput.addEventListener('input', (e) => {
-        clearTimeout(searchTimeout);
-        searchTimeout = setTimeout(() => {
-            this.searchQuery = e.target.value.toLowerCase();
-            this.filterListings();
-            this.renderFoodListings();
-        }, 300);
+    searchInput.addEventListener("input", (e) => {
+      clearTimeout(searchTimeout);
+      searchTimeout = setTimeout(() => {
+        this.searchQuery = e.target.value.toLowerCase();
+        this.filterListings();
+        this.renderFoodListings();
+      }, 300);
     });
 
     // --- NEW: Dropdown and Filtering Logic ---
-    const dietaryBtn = document.getElementById('dietary-filter-btn');
-    const dietaryDropdown = document.getElementById('dietary-dropdown');
-    const dietaryCheckboxes = document.querySelectorAll('input[name="dietary-filter"]');
+    const dietaryBtn = document.getElementById("dietary-filter-btn");
+    const dietaryDropdown = document.getElementById("dietary-dropdown");
+    const dietaryCheckboxes = document.querySelectorAll(
+      'input[name="dietary-filter"]'
+    );
 
     if (dietaryBtn) {
-        // Toggle dropdown visibility
-        dietaryBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            dietaryDropdown.style.display = dietaryDropdown.style.display === 'block' ? 'none' : 'block';
-            dietaryBtn.classList.toggle('active');
-        });
+      // Toggle dropdown visibility
+      dietaryBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        dietaryDropdown.style.display =
+          dietaryDropdown.style.display === "block" ? "none" : "block";
+        dietaryBtn.classList.toggle("active");
+      });
 
-        // Add event listeners to checkboxes
-        dietaryCheckboxes.forEach(checkbox => {
-            checkbox.addEventListener('change', () => {
-                this.filterListings();
-                this.renderFoodListings();
-                
-                // Update button text to show selected count
-                const selectedCount = document.querySelectorAll('input[name="dietary-filter"]:checked').length;
-                const btnSpan = dietaryBtn.querySelector('span');
-                if (selectedCount > 0) {
-                    btnSpan.textContent = `Dietary Filters (${selectedCount})`;
-                } else {
-                    btnSpan.textContent = 'Dietary Filters';
-                }
-            });
-        });
+      // Add event listeners to checkboxes
+      dietaryCheckboxes.forEach((checkbox) => {
+        checkbox.addEventListener("change", () => {
+          this.filterListings();
+          this.renderFoodListings();
 
-        // Close dropdown when clicking outside
-        document.addEventListener('click', () => {
-            if (dietaryDropdown.style.display === 'block') {
-                dietaryDropdown.style.display = 'none';
-                dietaryBtn.classList.remove('active');
-            }
+          // Update button text to show selected count
+          const selectedCount = document.querySelectorAll(
+            'input[name="dietary-filter"]:checked'
+          ).length;
+          const btnSpan = dietaryBtn.querySelector("span");
+          if (selectedCount > 0) {
+            btnSpan.textContent = `Dietary Filters (${selectedCount})`;
+          } else {
+            btnSpan.textContent = "Dietary Filters";
+          }
         });
-        
-        // Prevent closing when clicking inside the dropdown
-        dietaryDropdown.addEventListener('click', (e) => {
-            e.stopPropagation();
-        });
-    }
-}
+      });
 
-    filterListings() {
-        const activeDietaryFilters = [];
-        document.querySelectorAll('input[name="dietary-filter"]:checked').forEach(checkbox => {
-            activeDietaryFilters.push(checkbox.value);
-        });
-
-        this.filteredListings = this.foodListings.filter(listing => {
-            const matchesFilter = this.currentFilter === 'all' || listing.category === this.currentFilter;
-            
-            const matchesSearch = !this.searchQuery || 
-                listing.foodType.toLowerCase().includes(this.searchQuery) ||
-                listing.location.toLowerCase().includes(this.searchQuery) ||
-                listing.description.toLowerCase().includes(this.searchQuery);
-
-            const matchesDietary = activeDietaryFilters.length === 0 || 
-                (listing.dietaryTags && activeDietaryFilters.every(filter => listing.dietaryTags.includes(filter)));
-            
-            return matchesFilter && matchesSearch && matchesDietary;
-        });
-    }
-
-    setupResponsiveNav() {
-        const hamburger = document.querySelector('.hamburger');
-        const navMenu = document.querySelector('.nav-menu');
-        
-        hamburger.addEventListener('click', () => {
-            hamburger.classList.toggle('active');
-            navMenu.classList.toggle('active');
-        });
-    }
-
-    setupStatsAnimation() {
-        const stats = document.querySelectorAll('.stat-number');
-        let animated = false;
-        
-        const animateStats = () => {
-            if (animated) return;
-            
-            stats.forEach(stat => {
-                const target = parseInt(stat.getAttribute('data-count'));
-                const duration = 2000;
-                const increment = target / (duration / 16);
-                let current = 0;
-                
-                const updateStat = () => {
-                    current += increment;
-                    if (current < target) {
-                        stat.textContent = Math.floor(current);
-                        requestAnimationFrame(updateStat);
-                    } else {
-                        stat.textContent = target;
-                    }
-                };
-                
-                updateStat();
-            });
-            
-            animated = true;
-        };
-        
-        // Trigger animation when hero section is in view
-        const observer = new IntersectionObserver((entries) => {
-            entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                    setTimeout(animateStats, 1000);
-                }
-            });
-        });
-        
-        const heroStats = document.querySelector('.hero-stats');
-        if (heroStats) {
-            observer.observe(heroStats);
+      // Close dropdown when clicking outside
+      document.addEventListener("click", () => {
+        if (dietaryDropdown.style.display === "block") {
+          dietaryDropdown.style.display = "none";
+          dietaryBtn.classList.remove("active");
         }
-    }
+      });
 
-    setupScrollEffects() {
-        // Navbar background on scroll
-        const handleScroll = () => {
-            const navbar = document.querySelector('.navbar');
-            if (!navbar) return;
-            if (window.scrollY > 50) {
-                navbar.classList.add('scrolled');
-            } else {
-                navbar.classList.remove('scrolled');
-            }
+      // Prevent closing when clicking inside the dropdown
+      dietaryDropdown.addEventListener("click", (e) => {
+        e.stopPropagation();
+      });
+    }
+  }
+
+  filterListings() {
+    const activeDietaryFilters = [];
+    document
+      .querySelectorAll('input[name="dietary-filter"]:checked')
+      .forEach((checkbox) => {
+        activeDietaryFilters.push(checkbox.value);
+      });
+
+    this.filteredListings = this.foodListings.filter((listing) => {
+      const matchesFilter =
+        this.currentFilter === "all" || listing.category === this.currentFilter;
+
+      const matchesSearch =
+        !this.searchQuery ||
+        listing.foodType.toLowerCase().includes(this.searchQuery) ||
+        listing.location.toLowerCase().includes(this.searchQuery) ||
+        listing.description.toLowerCase().includes(this.searchQuery);
+
+      const matchesDietary =
+        activeDietaryFilters.length === 0 ||
+        (listing.dietaryTags &&
+          activeDietaryFilters.every((filter) =>
+            listing.dietaryTags.includes(filter)
+          ));
+
+      return matchesFilter && matchesSearch && matchesDietary;
+    });
+  }
+
+  setupResponsiveNav() {
+    const hamburger = document.querySelector(".hamburger");
+    const navMenu = document.querySelector(".nav-menu");
+
+    hamburger.addEventListener("click", () => {
+      hamburger.classList.toggle("active");
+      navMenu.classList.toggle("active");
+    });
+  }
+
+  setupStatsAnimation() {
+    const stats = document.querySelectorAll(".stat-number");
+    let animated = false;
+
+    const animateStats = () => {
+      if (animated) return;
+
+      stats.forEach((stat) => {
+        const target = parseInt(stat.getAttribute("data-count"));
+        const duration = 2000;
+        const increment = target / (duration / 16);
+        let current = 0;
+
+        const updateStat = () => {
+          current += increment;
+          if (current < target) {
+            stat.textContent = Math.floor(current);
+            requestAnimationFrame(updateStat);
+          } else {
+            stat.textContent = target;
+          }
         };
-        window.addEventListener('scroll', handleScroll);
-        handleScroll();
-        
-        // Animate elements on scroll
-        this.setupScrollAnimations();
+
+        updateStat();
+      });
+
+      animated = true;
+    };
+
+    // Trigger animation when hero section is in view
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setTimeout(animateStats, 1000);
+        }
+      });
+    });
+
+    const heroStats = document.querySelector(".hero-stats");
+    if (heroStats) {
+      observer.observe(heroStats);
     }
+  }
 
-    setupScrollAnimations() {
-        const observerOptions = {
-            threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
-        };
-        
-        const observer = new IntersectionObserver((entries) => {
-            entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                    entry.target.classList.add('animate-in');
-                }
-            });
-        }, observerOptions);
-        
-        // Observe elements to animate
-        const elementsToAnimate = document.querySelectorAll('.feature-card, .food-card, .impact-item');
-        elementsToAnimate.forEach(el => {
-            observer.observe(el);
-        });
-    }
+  setupScrollEffects() {
+    // Navbar background on scroll
+    const handleScroll = () => {
+      const navbar = document.querySelector(".navbar");
+      if (!navbar) return;
+      if (window.scrollY > 50) {
+        navbar.classList.add("scrolled");
+      } else {
+        navbar.classList.remove("scrolled");
+      }
+    };
+    window.addEventListener("scroll", handleScroll);
+    handleScroll();
 
-    generateSampleListings() {
-        const sampleListings = [
-            {
-                id: 1,
-                foodType: "Fresh Pizza Margherita",
-                quantity: "8 slices",
-                category: "restaurant",
-                description: "Freshly made pizza with mozzarella, tomato sauce, and basil. Perfect condition, just from lunch service.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "18:00",
-                location: "Mario's Pizzeria, 123 Main Street",
-                contact: "+1 234-567-8900",
-                createdAt: new Date(Date.now() - 3600000),
-                donor: "Mario's Pizzeria",
-                dietaryTags: ["vegetarian"],
-                photoUrl: "https://www.allrecipes.com/thmb/2rQA_OlnLbhidei70glz6HCCYAs=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/1453815-authentic-pizza-margherita-Cynthia-Ross-4x3-1-7410c69552274163a9049342b60c22ff.jpg",
-            },
-            {
-                id: 2,
-                foodType: "Assorted Sandwiches",
-                quantity: "15 sandwiches",
-                category: "event",
-                description: "Various sandwiches including turkey, ham, and vegetarian options from corporate catering event.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "16:30",
-                location: "Downtown Conference Center",
-                contact: "events@conference.com",
-                createdAt: new Date(Date.now() - 7200000),
-                donor: "Conference Center",
-                dietaryTags: ["non-vegetarian"],
-                photoUrl: "https://bangkok.mandarinorientalshop.com/cdn/shop/files/078-_3729_2048x.jpg?v=1690709512",
+    // Animate elements on scroll
+    this.setupScrollAnimations();
+  }
 
-            },
-            {
-                id: 3,
-                foodType: "Fresh Bread & Pastries",
-                quantity: "20+ items",
-                category: "bakery",
-                description: "End-of-day fresh bread, croissants, and pastries. All baked today and still perfectly fresh.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "20:00",
-                location: "Sunrise Bakery, Oak Avenue",
-                contact: "+1 234-567-8901",
-                createdAt: new Date(Date.now() - 1800000),
-                donor: "Sunrise Bakery",
-                dietaryTags: ["dairy-free"],
-                photoUrl: "https://media.istockphoto.com/id/507021914/photo/assorted-croissand-and-bread.jpg?s=612x612&w=0&k=20&c=ruHrARluyF_yR1-hmrurOyz4sLPNeohj1zKKv8fHa8U=",
-            },
-            {
-                id: 4,
-                foodType: "Home-cooked Curry",
-                quantity: "4-6 portions",
-                category: "household",
-                description: "Vegetarian curry with rice, made too much for family dinner. Spice level: medium.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "19:00",
-                location: "Residential Area, Pine Street",
-                contact: "+1 234-567-8902",
-                createdAt: new Date(Date.now() - 900000),
-                donor: "Local Family",
-                dietaryTags: ["vegetarian", "gluten-free"],
-                photoUrl: "https://www.tasteofhome.com/wp-content/uploads/2019/04/shutterstock_610126394.jpg",
-            },
-            {
-                id: 5,
-                foodType: "Fruit & Vegetable Box",
-                quantity: "1 large box",
-                category: "restaurant",
-                description: "Fresh produce includes apples, oranges, carrots, and lettuce.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "17:00",
-                location: "Green Garden Restaurant",
-                contact: "+1 234-567-8903",
-                createdAt: new Date(Date.now() - 5400000),
-                donor: "Green Garden Restaurant",
-                dietaryTags: ["vegan"],
-                photoUrl: "https://www.firstchoiceproduce.com/wp-content/uploads/2020/03/small-produce-box.jpg",
-            },
-            {
-                id: 6,
-                foodType: "Grilled Chicken Meals",
-                quantity: "12 complete meals",
-                category: "restaurant",
-                description: "Grilled chicken with rice and vegetables. Prepared for cancelled catering order.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "18:30",
-                location: "Healthy Eats Cafe, Market Square",
-                contact: "+1 234-567-8904",
-                createdAt: new Date(Date.now() - 2700000),
-                donor: "Healthy Eats Cafe",
-                dietaryTags: ["non-vegetarian", "dairy-free"],
-                photoUrl: "https://i0.wp.com/smittenkitchen.com/wp-content/uploads/2019/05/exceptional-grilled-chicken-scaled.jpg?fit=1200%2C800&ssl=1",
-            },
-            {
-                id: 7,
-                foodType: "Fresh Fruit Smoothies",
-                quantity: "10 bottles",
-                category: "Juice Bar",
-                description: "Blended today morning with real fruit. Chilled and fresh.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "17:52",
-                location: "Vita Juice Bar, Downtown Plaza",
-                contact: "+1 234-567-8908",
-                createdAt: new Date(Date.now() - 5400000),
-                donor: "Vita Juice Bar",
-                dietaryTags: ["vegan","sugar-free"],
-                photoUrl: "https://steviabenefits.org/wp-content/uploads/2017/02/AdobeStock_110772899.jpeg",
-            },
-            {
-                id: 8,
-                foodType: "Chocolate Muffins",
-                quantity: "15 muffins",
-                category: "Bakery",
-                description: "Soft and rich chocolate muffins. Fresh, sweet, and perfect for evening snacks.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "16:30",
-                location: "Sweet Dream Bakery, Park Street",
-                contact: "+1 234-567-8903",
-                createdAt: new Date(Date.now() - 5400000),
-                donor: "Sweet Dream Bakery",
-                dietaryTags: ["vegetarian"],
-                photoUrl: "https://images.unsplash.com/photo-1662980481668-7da79df5db26?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&q=80&w=1170",
-            },
-            {
-                id: 9,
-                foodType: "Chicken Noodles",
-                quantity: "2 boxes",
-                category: "restaurant",
-                description: "Freshly tossed noodles with vegetables, chicken and soy sauce.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "17:10",
-                location: "Dexter Restaurant, Spy Square",
-                contact: "+1 234-567-8893",
-                createdAt: new Date(Date.now() - 5400000),
-                donor: "Dexter Restaurant",
-                dietaryTags: ["non-vegetarian"],
-                photoUrl: "https://plus.unsplash.com/premium_photo-1677000666741-17c3c57139a2?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&q=80&w=687",
-            },
-            {
-                id: 10,
-                foodType: "Sushi Delights",
-                quantity: "22 pieces",
-                category: "restaurant",
-                description: "Assorted sushi rolls with salmon, avocado, and cucumber. Stored under refrigeration.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "18:32",
-                location: "Tokyo Table Restaurant, Palm Street",
-                contact: "+1 914-597-8893",
-                createdAt: new Date(Date.now() - 5400000),
-                donor: "Tokyo Table Restaurant",
-                dietaryTags: ["non-vegetarian", "seafood"],
-                photoUrl: "https://images.unsplash.com/photo-1564489563601-c53cfc451e93?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&q=80&w=687",
-            },
-            {
-                id: 11,
-                foodType: "Chicken Caesar Wraps",
-                quantity: "12 pieces",
-                category: "restaurant",
-                description: "Grilled chicken, crisp lettuce, parmesan, wrapped in soft tortillas.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "19:00",
-                location: "Urban Bites Café, Elm Street",
-                contact: "+1 914-597-8893",
-                createdAt: new Date(Date.now() - 5400000),
-                donor: "Urban Bites Café",
-                dietaryTags: ["non-vegetarian"],
-                photoUrl: "https://beyond-meat-cms-production.s3.us-west-2.amazonaws.com/d354babb-c138-49da-8962-391cbcf07e8e.jpg",
-            },
-            {
-                id: 12,
-                foodType: "Tomato Chicken Lasagna",
-                quantity: "8 pieces",
-                category: "household",
-                description: "Layered pasta with rich tomato sauce, creamy béchamel, and melted cheese.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "18:40",
-                location: "Octal Residency, Palm Street",
-                contact: "+1 914-511-8111",
-                createdAt: new Date(Date.now() - 5400000),
-                donor: "Local Family",
-                dietaryTags: ["non-vegetarian", "contains-dairy"],
-                photoUrl: "https://images.unsplash.com/photo-1574894709920-11b28e7367e3?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&q=80&w=735",
-            },
-            
-        ];
-        
-        this.foodListings = sampleListings;
-        this.filteredListings = sampleListings;
-    }
+  setupScrollAnimations() {
+    const observerOptions = {
+      threshold: 0.1,
+      rootMargin: "0px 0px -50px 0px",
+    };
 
-    getRandomFutureDate() {
-        const now = new Date();
-        const hours = Math.floor(Math.random() * 48) + 2; // 2 to 50 hours from now
-        const futureDate = new Date(now.getTime() + hours * 60 * 60 * 1000);
-        return futureDate.toISOString().slice(0, 16);
-    }
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("animate-in");
+        }
+      });
+    }, observerOptions);
 
-    renderFoodListings() {
-        const foodGrid = document.getElementById('foodGrid');
-        
-        if (this.filteredListings.length === 0) {
-            foodGrid.innerHTML = `
+    // Observe elements to animate
+    const elementsToAnimate = document.querySelectorAll(
+      ".feature-card, .food-card, .impact-item"
+    );
+    elementsToAnimate.forEach((el) => {
+      observer.observe(el);
+    });
+  }
+
+  generateSampleListings() {
+    const sampleListings = [
+      {
+        id: 1,
+        foodType: "Fresh Pizza Margherita",
+        quantity: "8 slices",
+        category: "restaurant",
+        description:
+          "Freshly made pizza with mozzarella, tomato sauce, and basil. Perfect condition, just from lunch service.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "18:00",
+        location: "Mario's Pizzeria, 123 Main Street",
+        contact: "+1 234-567-8900",
+        createdAt: new Date(Date.now() - 3600000),
+        donor: "Mario's Pizzeria",
+        dietaryTags: ["vegetarian"],
+        photoUrl:
+          "https://www.allrecipes.com/thmb/2rQA_OlnLbhidei70glz6HCCYAs=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/1453815-authentic-pizza-margherita-Cynthia-Ross-4x3-1-7410c69552274163a9049342b60c22ff.jpg",
+      },
+      {
+        id: 2,
+        foodType: "Assorted Sandwiches",
+        quantity: "15 sandwiches",
+        category: "event",
+        description:
+          "Various sandwiches including turkey, ham, and vegetarian options from corporate catering event.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "16:30",
+        location: "Downtown Conference Center",
+        contact: "events@conference.com",
+        createdAt: new Date(Date.now() - 7200000),
+        donor: "Conference Center",
+        dietaryTags: ["non-vegetarian"],
+        photoUrl:
+          "https://bangkok.mandarinorientalshop.com/cdn/shop/files/078-_3729_2048x.jpg?v=1690709512",
+      },
+      {
+        id: 3,
+        foodType: "Fresh Bread & Pastries",
+        quantity: "20+ items",
+        category: "bakery",
+        description:
+          "End-of-day fresh bread, croissants, and pastries. All baked today and still perfectly fresh.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "20:00",
+        location: "Sunrise Bakery, Oak Avenue",
+        contact: "+1 234-567-8901",
+        createdAt: new Date(Date.now() - 1800000),
+        donor: "Sunrise Bakery",
+        dietaryTags: ["dairy-free"],
+        photoUrl:
+          "https://media.istockphoto.com/id/507021914/photo/assorted-croissand-and-bread.jpg?s=612x612&w=0&k=20&c=ruHrARluyF_yR1-hmrurOyz4sLPNeohj1zKKv8fHa8U=",
+      },
+      {
+        id: 4,
+        foodType: "Home-cooked Curry",
+        quantity: "4-6 portions",
+        category: "household",
+        description:
+          "Vegetarian curry with rice, made too much for family dinner. Spice level: medium.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "19:00",
+        location: "Residential Area, Pine Street",
+        contact: "+1 234-567-8902",
+        createdAt: new Date(Date.now() - 900000),
+        donor: "Local Family",
+        dietaryTags: ["vegetarian", "gluten-free"],
+        photoUrl:
+          "https://www.tasteofhome.com/wp-content/uploads/2019/04/shutterstock_610126394.jpg",
+      },
+      {
+        id: 5,
+        foodType: "Fruit & Vegetable Box",
+        quantity: "1 large box",
+        category: "restaurant",
+        description:
+          "Fresh produce includes apples, oranges, carrots, and lettuce.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "17:00",
+        location: "Green Garden Restaurant",
+        contact: "+1 234-567-8903",
+        createdAt: new Date(Date.now() - 5400000),
+        donor: "Green Garden Restaurant",
+        dietaryTags: ["vegan"],
+        photoUrl:
+          "https://www.firstchoiceproduce.com/wp-content/uploads/2020/03/small-produce-box.jpg",
+      },
+      {
+        id: 6,
+        foodType: "Grilled Chicken Meals",
+        quantity: "12 complete meals",
+        category: "restaurant",
+        description:
+          "Grilled chicken with rice and vegetables. Prepared for cancelled catering order.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "18:30",
+        location: "Healthy Eats Cafe, Market Square",
+        contact: "+1 234-567-8904",
+        createdAt: new Date(Date.now() - 2700000),
+        donor: "Healthy Eats Cafe",
+        dietaryTags: ["non-vegetarian", "dairy-free"],
+        photoUrl:
+          "https://i0.wp.com/smittenkitchen.com/wp-content/uploads/2019/05/exceptional-grilled-chicken-scaled.jpg?fit=1200%2C800&ssl=1",
+      },
+      {
+        id: 7,
+        foodType: "Fresh Fruit Smoothies",
+        quantity: "10 bottles",
+        category: "Juice Bar",
+        description:
+          "Blended today morning with real fruit. Chilled and fresh.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "17:52",
+        location: "Vita Juice Bar, Downtown Plaza",
+        contact: "+1 234-567-8908",
+        createdAt: new Date(Date.now() - 5400000),
+        donor: "Vita Juice Bar",
+        dietaryTags: ["vegan", "sugar-free"],
+        photoUrl:
+          "https://steviabenefits.org/wp-content/uploads/2017/02/AdobeStock_110772899.jpeg",
+      },
+      {
+        id: 8,
+        foodType: "Chocolate Muffins",
+        quantity: "15 muffins",
+        category: "Bakery",
+        description:
+          "Soft and rich chocolate muffins. Fresh, sweet, and perfect for evening snacks.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "16:30",
+        location: "Sweet Dream Bakery, Park Street",
+        contact: "+1 234-567-8903",
+        createdAt: new Date(Date.now() - 5400000),
+        donor: "Sweet Dream Bakery",
+        dietaryTags: ["vegetarian"],
+        photoUrl:
+          "https://images.unsplash.com/photo-1662980481668-7da79df5db26?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&q=80&w=1170",
+      },
+      {
+        id: 9,
+        foodType: "Chicken Noodles",
+        quantity: "2 boxes",
+        category: "restaurant",
+        description:
+          "Freshly tossed noodles with vegetables, chicken and soy sauce.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "17:10",
+        location: "Dexter Restaurant, Spy Square",
+        contact: "+1 234-567-8893",
+        createdAt: new Date(Date.now() - 5400000),
+        donor: "Dexter Restaurant",
+        dietaryTags: ["non-vegetarian"],
+        photoUrl:
+          "https://plus.unsplash.com/premium_photo-1677000666741-17c3c57139a2?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&q=80&w=687",
+      },
+      {
+        id: 10,
+        foodType: "Sushi Delights",
+        quantity: "22 pieces",
+        category: "restaurant",
+        description:
+          "Assorted sushi rolls with salmon, avocado, and cucumber. Stored under refrigeration.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "18:32",
+        location: "Tokyo Table Restaurant, Palm Street",
+        contact: "+1 914-597-8893",
+        createdAt: new Date(Date.now() - 5400000),
+        donor: "Tokyo Table Restaurant",
+        dietaryTags: ["non-vegetarian", "seafood"],
+        photoUrl:
+          "https://images.unsplash.com/photo-1564489563601-c53cfc451e93?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&q=80&w=687",
+      },
+      {
+        id: 11,
+        foodType: "Chicken Caesar Wraps",
+        quantity: "12 pieces",
+        category: "restaurant",
+        description:
+          "Grilled chicken, crisp lettuce, parmesan, wrapped in soft tortillas.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "19:00",
+        location: "Urban Bites Café, Elm Street",
+        contact: "+1 914-597-8893",
+        createdAt: new Date(Date.now() - 5400000),
+        donor: "Urban Bites Café",
+        dietaryTags: ["non-vegetarian"],
+        photoUrl:
+          "https://beyond-meat-cms-production.s3.us-west-2.amazonaws.com/d354babb-c138-49da-8962-391cbcf07e8e.jpg",
+      },
+      {
+        id: 12,
+        foodType: "Tomato Chicken Lasagna",
+        quantity: "8 pieces",
+        category: "household",
+        description:
+          "Layered pasta with rich tomato sauce, creamy béchamel, and melted cheese.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "18:40",
+        location: "Octal Residency, Palm Street",
+        contact: "+1 914-511-8111",
+        createdAt: new Date(Date.now() - 5400000),
+        donor: "Local Family",
+        dietaryTags: ["non-vegetarian", "contains-dairy"],
+        photoUrl:
+          "https://images.unsplash.com/photo-1574894709920-11b28e7367e3?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&q=80&w=735",
+      },
+    ];
+
+    this.foodListings = sampleListings;
+    this.filteredListings = sampleListings;
+  }
+
+  getRandomFutureDate() {
+    const now = new Date();
+    const hours = Math.floor(Math.random() * 48) + 2; // 2 to 50 hours from now
+    const futureDate = new Date(now.getTime() + hours * 60 * 60 * 1000);
+    return futureDate.toISOString().slice(0, 16);
+  }
+
+  renderFoodListings() {
+    const foodGrid = document.getElementById("foodGrid");
+
+    if (this.filteredListings.length === 0) {
+      foodGrid.innerHTML = `
                 <div class="no-listings">
                     <i class="fas fa-search" style="font-size: 3rem; color: var(--medium-gray); margin-bottom: 1rem;"></i>
                     <h3>No listings found</h3>
                     <p>Try adjusting your filters or search terms.</p>
                 </div>
             `;
-            return;
-        }
-        
-        foodGrid.innerHTML = this.filteredListings.map(listing => this.createFoodCard(listing)).join('');
-        
-        // Add event listeners to food cards
-        this.setupFoodCardInteractions();
+      return;
     }
 
-    createClaimButton(listing) {
-        const isClaimed = this.claimedItems.includes(listing.id);
-        const isCollector = this.currentRole === 'collector';
-        const username = JSON.parse(localStorage.getItem('user'))?.name;
+    foodGrid.innerHTML = this.filteredListings
+      .map((listing) => this.createFoodCard(listing))
+      .join("");
 
-        if(username) {
-            if (isClaimed) {
-            return `
+    // Add event listeners to food cards
+    this.setupFoodCardInteractions();
+  }
+
+  createClaimButton(listing) {
+    const isClaimed = this.claimedItems.includes(listing.id);
+    const isCollector = this.currentRole === "collector";
+    const username = JSON.parse(localStorage.getItem("user"))?.name;
+
+    if (username) {
+      if (isClaimed) {
+        return `
                 <button class="claim-btn claimed" disabled>
                     <i class="fas fa-check-circle"></i> Claimed
                 </button>
             `;
-            } else if (isCollector) {
-                return `
+      } else if (isCollector) {
+        return `
                     <button class="claim-btn" data-id="${listing.id}">
                         <i class="fas fa-hand-paper"></i> Claim Food
                     </button>
                 `;
-            } else {
-                return `
+      } else {
+        return `
                     <button class="claim-btn" style="opacity: 0.5; cursor: not-allowed;" disabled>
                         <i class="fas fa-hand-paper"></i> Switch to Collector
                     </button>
                 `;
-            }
-        } else {
-            return `
+      }
+    } else {
+      return `
                 <button class="claim-btn" style="opacity: 0.5; cursor: not-allowed;" disabled>
                     <i class="fas fa-hand-paper"></i> Login to Claim
                 </button>
             `;
-        }
     }
+  }
 
-    createFoodCard(listing) {
+  createFoodCard(listing) {
     const timeAgo = this.getTimeAgo(listing.createdAt);
     const freshUntil = this.formatDateTime(listing.freshUntil);
     const isClaimed = this.claimedItems.includes(listing.id);
 
     // *** MODIFIED LOGIC START ***
-    let imgSource = '';
+    let imgSource = "";
 
     if (listing.photoUrl) {
-        // 1. Use external/sample URL if provided
-        imgSource = listing.photoUrl;
-    } else if (listing.photo && typeof listing.photo === 'object' && listing.photo instanceof File) {
-        // 2. Use temporary URL for newly uploaded file objects
-        imgSource = URL.createObjectURL(listing.photo);
-    } 
+      // 1. Use external/sample URL if provided
+      imgSource = listing.photoUrl;
+    } else if (
+      listing.photo &&
+      typeof listing.photo === "object" &&
+      listing.photo instanceof File
+    ) {
+      // 2. Use temporary URL for newly uploaded file objects
+      imgSource = URL.createObjectURL(listing.photo);
+    }
     // If neither photoUrl nor a valid File object exists, imgSource remains empty.
-    
+
     // Create the image/icon HTML based on the determined source
-    const imageHTML = imgSource 
-        ? `<img src="${imgSource}" alt="${listing.foodType}">` 
-        : `<i class="fas fa-${this.getFoodIcon(listing.category)}"></i>`;
+    const imageHTML = imgSource
+      ? `<img src="${imgSource}" alt="${listing.foodType}">`
+      : `<i class="fas fa-${this.getFoodIcon(listing.category)}"></i>`;
     // *** MODIFIED LOGIC END ***
 
     // This logic generates the HTML for the tags
-    let tagsHTML = '';
+    let tagsHTML = "";
     if (listing.dietaryTags && listing.dietaryTags.length > 0) {
-        tagsHTML = `<div class="food-tags">` +
-            listing.dietaryTags.map(tag => `<span class="tag tag-${tag}">${tag}</span>`).join('') +
+      tagsHTML =
+        `<div class="food-tags">` +
+        listing.dietaryTags
+          .map((tag) => `<span class="tag tag-${tag}">${tag}</span>`)
+          .join("") +
         `</div>`;
     }
-    
+
     // The main HTML template now uses the correctly generated imageHTML
     return `
-        <div class="food-card ${isClaimed ? 'claimed' : ''}" 
+        <div class="food-card ${isClaimed ? "claimed" : ""}" 
              data-id="${listing.id}" 
-             data-tags="${listing.dietaryTags ? listing.dietaryTags.join(',') : ''}">
+             data-tags="${
+               listing.dietaryTags ? listing.dietaryTags.join(",") : ""
+             }">
             <div class="food-image">
                 ${imageHTML}
-                <div class="food-category">${this.capitalizeFirst(listing.category)}</div>
+                <div class="food-category">${this.capitalizeFirst(
+                  listing.category
+                )}</div>
             </div>
             <div class="food-details">
                 <h3 class="food-title">${listing.foodType}</h3>
                 ${tagsHTML} 
                 <p class="food-description">${listing.description}</p>
                 <div class="food-meta">
-                    <span class="quantity"><i class="fas fa-utensils"></i> ${listing.quantity}</span>
+                    <span class="quantity"><i class="fas fa-utensils"></i> ${
+                      listing.quantity
+                    }</span>
                     <span class="freshness"><i class="fas fa-clock"></i> ${freshUntil}</span>
                 </div>
                 <div class="food-location">
@@ -1012,314 +1110,362 @@ handleFileSelect(file) {
                 </div>
                 <div class="food-actions">
                     ${this.createClaimButton(listing)}
-                    <button class="contact-btn" data-contact="${listing.contact}">
+                    <!-- Make explicit type to avoid accidental form submits and add aria-label -->
+                    <button type="button" class="contact-btn" data-contact="${
+                      listing.contact
+                    }" aria-label="Copy contact">
                         <i class="fas fa-phone"></i>
                     </button>
                 </div>
             </div>
         </div>
     `;
-}
+  }
 
-    setupFoodCardInteractions() {
-        // Claim buttons
-        const claimBtns = document.querySelectorAll('.claim-btn');
-        claimBtns.forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const listingId = parseInt(btn.getAttribute('data-id'));
-                this.handleClaimFood(listingId);
-            });
-        });
-        
-        // Contact buttons
-        const contactBtns = document.querySelectorAll('.contact-btn');
-        contactBtns.forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const contact = btn.getAttribute('data-contact');
-                this.handleContactDonor(contact);
-            });
-        });
+  setupFoodCardInteractions() {
+    // Claim buttons
+    const claimBtns = document.querySelectorAll(".claim-btn");
+    claimBtns.forEach((btn) => {
+      btn.addEventListener("click", (e) => {
+        const listingId = parseInt(btn.getAttribute("data-id"));
+        this.handleClaimFood(listingId);
+      });
+    });
+
+    // Contact buttons
+    const contactBtns = document.querySelectorAll(".contact-btn");
+    contactBtns.forEach((btn) => {
+      btn.addEventListener("click", (e) => {
+        // Prevent default behavior and stop propagation to avoid
+        // accidental form submission or page-level click handlers that
+        // were causing a brief page flash.
+        e.preventDefault();
+        e.stopPropagation();
+
+        const contact = btn.getAttribute("data-contact");
+        this.handleContactDonor(contact);
+      });
+    });
+  }
+
+  handleClaimFood(listingId) {
+    const listing = this.foodListings.find((l) => l.id === listingId);
+    if (!listing) return;
+
+    // Check if already claimed
+    if (this.claimedItems.includes(listingId)) {
+      this.showToast("This item has already been claimed!", "error");
+      return;
     }
 
-    handleClaimFood(listingId) {
-        const listing = this.foodListings.find(l => l.id === listingId);
-        if (!listing) return;
-        
-        // Check if already claimed
-        if (this.claimedItems.includes(listingId)) {
-            this.showToast('This item has already been claimed!', 'error');
-            return;
+    // Show confirmation dialog
+    const confirmed = confirm(
+      `Claim "${listing.foodType}" from ${listing.donor}?\n\nPickup: ${
+        listing.location
+      }\nTime: ${this.formatTime(listing.pickupTime)}\nContact: ${
+        listing.contact
+      }`
+    );
+
+    if (confirmed) {
+      // Add to claimed items
+      this.claimedItems.push(listingId);
+      this.saveClaimedItems();
+
+      // Create notification
+      const notification = {
+        id: Date.now(),
+        listingId: listingId,
+        foodType: listing.foodType,
+        donor: listing.donor,
+        location: listing.location,
+        pickupTime: listing.pickupTime,
+        contact: listing.contact,
+        claimedAt: new Date(),
+        status: "claimed",
+      };
+
+      this.addNotification(notification);
+
+      // Update button appearance only
+      const claimBtn = document.querySelector(`[data-id="${listingId}"]`);
+
+      if (claimBtn) {
+        claimBtn.classList.add("claimed");
+        claimBtn.innerHTML = '<i class="fas fa-check-circle"></i> Claimed';
+        claimBtn.disabled = true;
+      }
+
+      // Show success message
+      this.showToast(
+        `Successfully claimed "${listing.foodType}"! Check notifications for pickup details.`,
+        "success"
+      );
+
+      // Update notification display
+      this.updateNotificationDisplay();
+    }
+  }
+
+  handleContactDonor(contact) {
+    // Guard
+    if (!contact) return;
+
+    // Use async clipboard API when available. Keep the copy flow isolated so
+    // it doesn't cause layout changes or trigger page-level handlers.
+    navigator.clipboard
+      .writeText(contact)
+      .then(() => {
+        this.showToast("Contact information copied to clipboard!", "success");
+      })
+      .catch(() => {
+        // Fallback for older browsers: use an off-screen textarea so it doesn't
+        // cause scrolling or visual reflows which previously caused a flash.
+        const textArea = document.createElement("textarea");
+        textArea.value = contact;
+        textArea.setAttribute("aria-hidden", "true");
+        textArea.style.position = "fixed";
+        textArea.style.left = "-9999px";
+        textArea.style.top = "0";
+        document.body.appendChild(textArea);
+        textArea.select();
+        try {
+          document.execCommand("copy");
+          this.showToast("Contact information copied to clipboard!", "success");
+        } catch (err) {
+          this.showToast(
+            "Unable to copy contact information. Please copy manually.",
+            "error"
+          );
         }
-        
-        // Show confirmation dialog
-        const confirmed = confirm(`Claim "${listing.foodType}" from ${listing.donor}?\n\nPickup: ${listing.location}\nTime: ${this.formatTime(listing.pickupTime)}\nContact: ${listing.contact}`);
-        
-        if (confirmed) {
-            // Add to claimed items
-            this.claimedItems.push(listingId);
-            this.saveClaimedItems();
-            
-            // Create notification
-            const notification = {
-                id: Date.now(),
-                listingId: listingId,
-                foodType: listing.foodType,
-                donor: listing.donor,
-                location: listing.location,
-                pickupTime: listing.pickupTime,
-                contact: listing.contact,
-                claimedAt: new Date(),
-                status: 'claimed'
-            };
-            
-            this.addNotification(notification);
-            
-            // Update button appearance only
-            const claimBtn = document.querySelector(`[data-id="${listingId}"]`);
-            
-            if (claimBtn) {
-                claimBtn.classList.add('claimed');
-                claimBtn.innerHTML = '<i class="fas fa-check-circle"></i> Claimed';
-                claimBtn.disabled = true;
-            }
-            
-            // Show success message
-            this.showToast(`Successfully claimed "${listing.foodType}"! Check notifications for pickup details.`, 'success');
-            
-            // Update notification display
-            this.updateNotificationDisplay();
-        }
-    }
+        document.body.removeChild(textArea);
+      });
+  }
 
-    handleContactDonor(contact) {
-        // Copy contact to clipboard
-        navigator.clipboard.writeText(contact).then(() => {
-            this.showToast('Contact information copied to clipboard!', 'success');
-        }).catch(() => {
-            // Fallback for older browsers
-            const textArea = document.createElement('textarea');
-            textArea.value = contact;
-            document.body.appendChild(textArea);
-            textArea.select();
-            document.execCommand('copy');
-            document.body.removeChild(textArea);
-            this.showToast('Contact information copied to clipboard!', 'success');
-        });
-    }
+  getFoodIcon(category) {
+    const icons = {
+      restaurant: "store",
+      household: "home",
+      bakery: "bread-slice",
+      event: "calendar-alt",
+    };
+    return icons[category] || "utensils";
+  }
 
-    getFoodIcon(category) {
-        const icons = {
-            restaurant: 'store',
-            household: 'home',
-            bakery: 'bread-slice',
-            event: 'calendar-alt'
-        };
-        return icons[category] || 'utensils';
-    }
+  capitalizeFirst(str) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  }
 
-    capitalizeFirst(str) {
-        return str.charAt(0).toUpperCase() + str.slice(1);
-    }
+  getTimeAgo(date) {
+    const now = new Date();
+    const diff = now - date;
+    const minutes = Math.floor(diff / 60000);
+    const hours = Math.floor(minutes / 60);
 
-    getTimeAgo(date) {
-        const now = new Date();
-        const diff = now - date;
-        const minutes = Math.floor(diff / 60000);
-        const hours = Math.floor(minutes / 60);
-        
-        if (minutes < 60) {
-            return `${minutes}m ago`;
-        } else if (hours < 24) {
-            return `${hours}h ago`;
-        } else {
-            const days = Math.floor(hours / 24);
-            return `${days}d ago`;
-        }
+    if (minutes < 60) {
+      return `${minutes}m ago`;
+    } else if (hours < 24) {
+      return `${hours}h ago`;
+    } else {
+      const days = Math.floor(hours / 24);
+      return `${days}d ago`;
     }
+  }
 
-    formatDateTime(dateTimeString) {
-        const date = new Date(dateTimeString);
-        const now = new Date();
-        const diff = date - now;
-        const hours = Math.floor(diff / (1000 * 60 * 60));
-        
-        if (hours < 24) {
-            return `${hours}h left`;
-        } else {
-            const days = Math.floor(hours / 24);
-            return `${days}d left`;
-        }
+  formatDateTime(dateTimeString) {
+    const date = new Date(dateTimeString);
+    const now = new Date();
+    const diff = date - now;
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+
+    if (hours < 24) {
+      return `${hours}h left`;
+    } else {
+      const days = Math.floor(hours / 24);
+      return `${days}d left`;
     }
+  }
 
-    formatTime(timeString) {
-        const [hours, minutes] = timeString.split(':');
-        const date = new Date();
-        date.setHours(hours, minutes);
-        return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-    }
+  formatTime(timeString) {
+    const [hours, minutes] = timeString.split(":");
+    const date = new Date();
+    date.setHours(hours, minutes);
+    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
 
-    startAnimations() {
-        // Add stagger animation to feature cards
-        const featureCards = document.querySelectorAll('.feature-card');
-        featureCards.forEach((card, index) => {
-            card.style.animationDelay = `${index * 0.2}s`;
-        });
-        
-        // Add floating animation to hero elements
-        this.startFloatingAnimations();
-        
-        // Add periodic pulse to CTA buttons
-        this.startButtonPulse();
-    }
+  startAnimations() {
+    // Add stagger animation to feature cards
+    const featureCards = document.querySelectorAll(".feature-card");
+    featureCards.forEach((card, index) => {
+      card.style.animationDelay = `${index * 0.2}s`;
+    });
 
-    startFloatingAnimations() {
-        const floatingElements = document.querySelectorAll('.floating-card');
-        floatingElements.forEach((element, index) => {
-            element.style.animationDelay = `${index * 0.5}s`;
-        });
-    }
+    // Add floating animation to hero elements
+    this.startFloatingAnimations();
 
-    startButtonPulse() {
-        const ctaButtons = document.querySelectorAll('.btn-primary');
-        setInterval(() => {
-            ctaButtons.forEach((btn, index) => {
-                setTimeout(() => {
-                    btn.style.animation = 'pulse 0.6s ease';
-                    setTimeout(() => {
-                        btn.style.animation = '';
-                    }, 600);
-                }, index * 200);
-            });
-        }, 10000); // Pulse every 10 seconds
-    }
+    // Add periodic pulse to CTA buttons
+    this.startButtonPulse();
+  }
 
-    hideLoadingOverlay() {
-        const loadingOverlay = document.getElementById('loadingOverlay');
+  startFloatingAnimations() {
+    const floatingElements = document.querySelectorAll(".floating-card");
+    floatingElements.forEach((element, index) => {
+      element.style.animationDelay = `${index * 0.5}s`;
+    });
+  }
+
+  startButtonPulse() {
+    const ctaButtons = document.querySelectorAll(".btn-primary");
+    setInterval(() => {
+      ctaButtons.forEach((btn, index) => {
         setTimeout(() => {
-            loadingOverlay.style.opacity = '0';
-            setTimeout(() => {
-                loadingOverlay.style.display = 'none';
-            }, 500);
-        }, 1500); // Show loading for 1.5 seconds
+          btn.style.animation = "pulse 0.6s ease";
+          setTimeout(() => {
+            btn.style.animation = "";
+          }, 600);
+        }, index * 200);
+      });
+    }, 10000); // Pulse every 10 seconds
+  }
+
+  hideLoadingOverlay() {
+    const loadingOverlay = document.getElementById("loadingOverlay");
+    setTimeout(() => {
+      loadingOverlay.style.opacity = "0";
+      setTimeout(() => {
+        loadingOverlay.style.display = "none";
+      }, 500);
+    }, 1500); // Show loading for 1.5 seconds
+  }
+
+  // Notification System Methods
+  setupNotificationSystem() {
+    const notificationBell = document.getElementById("notificationBell");
+    const notificationPanel = document.getElementById("notificationPanel");
+
+    if (!notificationBell) return;
+
+    // Show notification bell when in collector mode or when there are notifications
+    if (this.currentRole === "collector" || this.notifications.length > 0) {
+      notificationBell.style.display = "block";
     }
 
-    // Notification System Methods
-    setupNotificationSystem() {
-        const notificationBell = document.getElementById('notificationBell');
-        const notificationPanel = document.getElementById('notificationPanel');
-        
-        if (!notificationBell) return;
-        
-        // Show notification bell when in collector mode or when there are notifications
-        if (this.currentRole === 'collector' || this.notifications.length > 0) {
-            notificationBell.style.display = 'block';
-        }
-        
-        // Toggle notification panel
-        notificationBell.addEventListener('click', (e) => {
-            e.stopPropagation();
-            const isActive = notificationPanel.classList.contains('active');
-            
-            if (isActive) {
-                notificationPanel.classList.remove('active');
-                notificationBell.classList.remove('active');
-            } else {
-                notificationPanel.classList.add('active');
-                notificationBell.classList.add('active');
-            }
-        });
-        
-        // Close panel when clicking outside
-        document.addEventListener('click', (e) => {
-            if (!notificationBell.contains(e.target)) {
-                notificationPanel.classList.remove('active');
-                notificationBell.classList.remove('active');
-            }
-        });
-        
-        // Prevent panel from closing when clicking inside
-        notificationPanel.addEventListener('click', (e) => {
-            e.stopPropagation();
-        });
+    // Toggle notification panel
+    notificationBell.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const isActive = notificationPanel.classList.contains("active");
+
+      if (isActive) {
+        notificationPanel.classList.remove("active");
+        notificationBell.classList.remove("active");
+      } else {
+        notificationPanel.classList.add("active");
+        notificationBell.classList.add("active");
+      }
+    });
+
+    // Close panel when clicking outside
+    document.addEventListener("click", (e) => {
+      if (!notificationBell.contains(e.target)) {
+        notificationPanel.classList.remove("active");
+        notificationBell.classList.remove("active");
+      }
+    });
+
+    // Prevent panel from closing when clicking inside
+    notificationPanel.addEventListener("click", (e) => {
+      e.stopPropagation();
+    });
+  }
+
+  loadClaimedItems() {
+    const stored = localStorage.getItem("sharebite-claimed-items");
+    return stored ? JSON.parse(stored) : [];
+  }
+
+  saveClaimedItems() {
+    localStorage.setItem(
+      "sharebite-claimed-items",
+      JSON.stringify(this.claimedItems)
+    );
+  }
+
+  loadNotifications() {
+    const stored = localStorage.getItem("sharebite-notifications");
+    return stored ? JSON.parse(stored) : [];
+  }
+
+  saveNotifications() {
+    localStorage.setItem(
+      "sharebite-notifications",
+      JSON.stringify(this.notifications)
+    );
+  }
+
+  addNotification(notification) {
+    this.notifications.unshift(notification);
+    this.saveNotifications();
+    this.updateNotificationDisplay();
+    this.renderNotifications();
+  }
+
+  updateNotificationDisplay() {
+    const notificationBell = document.getElementById("notificationBell");
+    const notificationBadge = document.getElementById("notificationBadge");
+
+    if (!notificationBell || !notificationBadge) return;
+
+    const unreadCount = this.notifications.length;
+
+    if (unreadCount > 0) {
+      notificationBell.style.display = "block";
+      notificationBadge.style.display = "flex";
+      notificationBadge.textContent =
+        unreadCount > 99 ? "99+" : unreadCount.toString();
+    } else {
+      notificationBadge.style.display = "none";
+      // Keep bell visible if in collector mode
+      if (this.currentRole !== "collector") {
+        notificationBell.style.display = "none";
+      }
     }
-    
-    loadClaimedItems() {
-        const stored = localStorage.getItem('sharebite-claimed-items');
-        return stored ? JSON.parse(stored) : [];
-    }
-    
-    saveClaimedItems() {
-        localStorage.setItem('sharebite-claimed-items', JSON.stringify(this.claimedItems));
-    }
-    
-    loadNotifications() {
-        const stored = localStorage.getItem('sharebite-notifications');
-        return stored ? JSON.parse(stored) : [];
-    }
-    
-    saveNotifications() {
-        localStorage.setItem('sharebite-notifications', JSON.stringify(this.notifications));
-    }
-    
-    addNotification(notification) {
-        this.notifications.unshift(notification);
-        this.saveNotifications();
-        this.updateNotificationDisplay();
-        this.renderNotifications();
-    }
-    
-    updateNotificationDisplay() {
-        const notificationBell = document.getElementById('notificationBell');
-        const notificationBadge = document.getElementById('notificationBadge');
-        
-        if (!notificationBell || !notificationBadge) return;
-        
-        const unreadCount = this.notifications.length;
-        
-        if (unreadCount > 0) {
-            notificationBell.style.display = 'block';
-            notificationBadge.style.display = 'flex';
-            notificationBadge.textContent = unreadCount > 99 ? '99+' : unreadCount.toString();
-        } else {
-            notificationBadge.style.display = 'none';
-            // Keep bell visible if in collector mode
-            if (this.currentRole !== 'collector') {
-                notificationBell.style.display = 'none';
-            }
-        }
-        
-        this.renderNotifications();
-    }
-    
-    renderNotifications() {
-        const notificationList = document.getElementById('notificationList');
-        if (!notificationList) return;
-        
-        if (this.notifications.length === 0) {
-            notificationList.innerHTML = `
+
+    this.renderNotifications();
+  }
+
+  renderNotifications() {
+    const notificationList = document.getElementById("notificationList");
+    if (!notificationList) return;
+
+    if (this.notifications.length === 0) {
+      notificationList.innerHTML = `
                 <div class="no-notifications">
                     <i class="fas fa-bell-slash"></i>
                     <h4>No claimed items yet</h4>
                     <p>Start claiming food items to see them here</p>
                 </div>
             `;
-            return;
-        }
-        
-        notificationList.innerHTML = `
+      return;
+    }
+
+    notificationList.innerHTML = `
             <div class="notification-content">
-                ${this.notifications.map(notification => this.createNotificationItem(notification)).join('')}
+                ${this.notifications
+                  .map((notification) =>
+                    this.createNotificationItem(notification)
+                  )
+                  .join("")}
             </div>
         `;
-        
-        // Add event listeners for notification actions
-        this.setupNotificationActions();
-    }
-    
-    createNotificationItem(notification) {
-        const timeAgo = this.getTimeAgo(notification.claimedAt);
-        
-        return `
+
+    // Add event listeners for notification actions
+    this.setupNotificationActions();
+  }
+
+  createNotificationItem(notification) {
+    const timeAgo = this.getTimeAgo(notification.claimedAt);
+
+    return `
             <div class="notification-item" data-id="${notification.id}">
                 <div class="notification-item-header">
                     <div class="notification-item-icon">
@@ -1337,7 +1483,9 @@ handleFileSelect(file) {
                         </div>
                         <div class="notification-detail">
                             <i class="fas fa-clock"></i>
-                            <span>Pickup: ${this.formatTime(notification.pickupTime)}</span>
+                            <span>Pickup: ${this.formatTime(
+                              notification.pickupTime
+                            )}</span>
                         </div>
                         <div class="notification-detail">
                             <i class="fas fa-phone"></i>
@@ -1347,28 +1495,32 @@ handleFileSelect(file) {
                 </div>
                 <div class="notification-meta">
                     <span class="notification-time">Claimed ${timeAgo}</span>
-                    <span class="notification-status">${this.capitalizeFirst(notification.status)}</span>
+                    <span class="notification-status">${this.capitalizeFirst(
+                      notification.status
+                    )}</span>
                 </div>
             </div>
         `;
-    }
-    
-    setupNotificationActions() {
-        const notificationItems = document.querySelectorAll('.notification-item');
-        
-        notificationItems.forEach(item => {
-            item.addEventListener('click', (e) => {
-                const notificationId = parseInt(item.getAttribute('data-id'));
-                this.viewNotificationDetails(notificationId);
-            });
-        });
-    }
-    
-    viewNotificationDetails(notificationId) {
-        const notification = this.notifications.find(n => n.id === notificationId);
-        if (!notification) return;
-        
-        const details = `
+  }
+
+  setupNotificationActions() {
+    const notificationItems = document.querySelectorAll(".notification-item");
+
+    notificationItems.forEach((item) => {
+      item.addEventListener("click", (e) => {
+        const notificationId = parseInt(item.getAttribute("data-id"));
+        this.viewNotificationDetails(notificationId);
+      });
+    });
+  }
+
+  viewNotificationDetails(notificationId) {
+    const notification = this.notifications.find(
+      (n) => n.id === notificationId
+    );
+    if (!notification) return;
+
+    const details = `
 Food: ${notification.foodType}
 Donor: ${notification.donor}
 Location: ${notification.location}
@@ -1378,222 +1530,235 @@ Claimed: ${new Date(notification.claimedAt).toLocaleString()}
 
 Contact information has been copied to clipboard.
         `;
-        
-        // Copy contact to clipboard
-        navigator.clipboard.writeText(notification.contact).then(() => {
-            alert(details);
-        }).catch(() => {
-            alert(details);
-        });
-    }
-    
-    clearAllNotifications() {
-        this.notifications = [];
-        this.claimedItems = [];
-        this.saveNotifications();
-        this.saveClaimedItems();
-        this.updateNotificationDisplay();
-    }
 
-    // Date Input Confirmation functionality
-    setupDateInputConfirmation() {
-        const freshUntilInput = document.getElementById('freshUntil');
-        if (!freshUntilInput) return;
+    // Copy contact to clipboard
+    navigator.clipboard
+      .writeText(notification.contact)
+      .then(() => {
+        alert(details);
+      })
+      .catch(() => {
+        alert(details);
+      });
+  }
 
-        const container = freshUntilInput.parentNode;
-        const checkmarkIcon = container.querySelector('.checkmark-icon');
+  clearAllNotifications() {
+    this.notifications = [];
+    this.claimedItems = [];
+    this.saveNotifications();
+    this.saveClaimedItems();
+    this.updateNotificationDisplay();
+  }
 
-        if (!checkmarkIcon) return;
+  // Date Input Confirmation functionality
+  setupDateInputConfirmation() {
+    const freshUntilInput = document.getElementById("freshUntil");
+    if (!freshUntilInput) return;
 
-        let isDateConfirmed = false;
-        let previousValue = freshUntilInput.value;
+    const container = freshUntilInput.parentNode;
+    const checkmarkIcon = container.querySelector(".checkmark-icon");
 
-        // Helper function to show checkmark only after date selection
-        const handleDateChange = () => {
-            const currentValue = freshUntilInput.value;
-            
-            // If value has changed from previous, reset confirmation status
-            if (currentValue !== previousValue) {
-                isDateConfirmed = false;
-            }
-            
-            // Only show checkmark if:
-            // 1. There's a new value
-            // 2. The value has changed from previous
-            // 3. Date hasn't been confirmed yet
-            if (currentValue && currentValue !== previousValue && !isDateConfirmed) {
-                checkmarkIcon.classList.remove('hidden');
-            }
-            
-            // If value is cleared, reset everything
-            if (!currentValue) {
-                checkmarkIcon.classList.add('hidden');
-                isDateConfirmed = false;
-            }
-            
-            previousValue = currentValue;
-        };
+    if (!checkmarkIcon) return;
 
-        // Helper function to confirm date and hide checkmark
-        const confirmDate = () => {
-            if (freshUntilInput.value && !isDateConfirmed) {
-                // Mark as confirmed
-                isDateConfirmed = true;
-                
-                // Hide the checkmark
-                checkmarkIcon.classList.add('hidden');
-                
-                // Show success toast
-                this.showToast('Date confirmed successfully!', 'success');
-                
-                // Move focus to next input field if available
-                const nextInput = freshUntilInput.closest('.form-group').parentElement.nextElementSibling?.querySelector('input');
-                if (nextInput) {
-                    setTimeout(() => nextInput.focus(), 200);
-                } else {
-                    freshUntilInput.blur(); // Remove focus from current input
-                }
-            }
-        };
+    let isDateConfirmed = false;
+    let previousValue = freshUntilInput.value;
 
-        // Initially hide checkmark
-        checkmarkIcon.classList.add('hidden');
+    // Helper function to show checkmark only after date selection
+    const handleDateChange = () => {
+      const currentValue = freshUntilInput.value;
 
-        // Listen for date selection changes
-        freshUntilInput.addEventListener('change', handleDateChange);
-        freshUntilInput.addEventListener('input', handleDateChange);
+      // If value has changed from previous, reset confirmation status
+      if (currentValue !== previousValue) {
+        isDateConfirmed = false;
+      }
 
-        // Checkmark click handler - confirm the date and hide checkmark
-        checkmarkIcon.addEventListener('click', (e) => {
-            e.stopPropagation(); // Prevent event bubbling
-            confirmDate();
-        });
+      // Only show checkmark if:
+      // 1. There's a new value
+      // 2. The value has changed from previous
+      // 3. Date hasn't been confirmed yet
+      if (currentValue && currentValue !== previousValue && !isDateConfirmed) {
+        checkmarkIcon.classList.remove("hidden");
+      }
 
-        // Click outside handler - hide checkmark when clicking outside
-        document.addEventListener('click', (e) => {
-            // Check if checkmark is currently visible
-            if (!checkmarkIcon.classList.contains('hidden')) {
-                // Check if click is outside the input container and not on the checkmark
-                if (!container.contains(e.target)) {
-                    // User clicked outside - confirm the date and hide checkmark
-                    confirmDate();
-                }
-            }
-        });
+      // If value is cleared, reset everything
+      if (!currentValue) {
+        checkmarkIcon.classList.add("hidden");
+        isDateConfirmed = false;
+      }
 
-        // Also hide checkmark when input loses focus (blur event)
-        freshUntilInput.addEventListener('blur', (e) => {
-            // Small delay to allow checkmark click to register first
-            setTimeout(() => {
-                if (!checkmarkIcon.classList.contains('hidden') && freshUntilInput.value) {
-                    confirmDate();
-                }
-            }, 100);
-        });
-    }
+      previousValue = currentValue;
+    };
 
-    // Time Input Confirmation functionality
-    setupTimeInputConfirmation() {
-        const pickupTimeInput = document.getElementById('pickupTime');
-        if (!pickupTimeInput) return;
+    // Helper function to confirm date and hide checkmark
+    const confirmDate = () => {
+      if (freshUntilInput.value && !isDateConfirmed) {
+        // Mark as confirmed
+        isDateConfirmed = true;
 
-        const container = pickupTimeInput.parentNode;
-        const checkmarkIcon = container.querySelector('.checkmark-icon-time');
+        // Hide the checkmark
+        checkmarkIcon.classList.add("hidden");
 
-        if (!checkmarkIcon) return;
+        // Show success toast
+        this.showToast("Date confirmed successfully!", "success");
 
-        let isTimeConfirmed = false;
-        let previousValue = pickupTimeInput.value;
+        // Move focus to next input field if available
+        const nextInput = freshUntilInput
+          .closest(".form-group")
+          .parentElement.nextElementSibling?.querySelector("input");
+        if (nextInput) {
+          setTimeout(() => nextInput.focus(), 200);
+        } else {
+          freshUntilInput.blur(); // Remove focus from current input
+        }
+      }
+    };
 
-        // Helper function to show checkmark only after time selection
-        const handleTimeChange = () => {
-            const currentValue = pickupTimeInput.value;
-            
-            // If value has changed from previous, reset confirmation status
-            if (currentValue !== previousValue) {
-                isTimeConfirmed = false;
-            }
-            
-            // Only show checkmark if:
-            // 1. There's a new value
-            // 2. The value has changed from previous
-            // 3. Time hasn't been confirmed yet
-            if (currentValue && currentValue !== previousValue && !isTimeConfirmed) {
-                checkmarkIcon.classList.remove('hidden');
-            }
-            
-            // If value is cleared, reset everything
-            if (!currentValue) {
-                checkmarkIcon.classList.add('hidden');
-                isTimeConfirmed = false;
-            }
-            
-            previousValue = currentValue;
-        };
+    // Initially hide checkmark
+    checkmarkIcon.classList.add("hidden");
 
-        // Helper function to confirm time and hide checkmark
-        const confirmTime = () => {
-            if (pickupTimeInput.value && !isTimeConfirmed) {
-                // Mark as confirmed
-                isTimeConfirmed = true;
-                
-                // Hide the checkmark
-                checkmarkIcon.classList.add('hidden');
-                
-                // Show success toast
-                this.showToast('Time confirmed successfully!', 'success');
-                
-                // Move focus to next input field if available
-                const nextInput = pickupTimeInput.closest('.form-group').parentElement.nextElementSibling?.querySelector('input');
-                if (nextInput) {
-                    setTimeout(() => nextInput.focus(), 200);
-                } else {
-                    pickupTimeInput.blur(); // Remove focus from current input
-                }
-            }
-        };
+    // Listen for date selection changes
+    freshUntilInput.addEventListener("change", handleDateChange);
+    freshUntilInput.addEventListener("input", handleDateChange);
 
-        // Initially hide checkmark
-        checkmarkIcon.classList.add('hidden');
+    // Checkmark click handler - confirm the date and hide checkmark
+    checkmarkIcon.addEventListener("click", (e) => {
+      e.stopPropagation(); // Prevent event bubbling
+      confirmDate();
+    });
 
-        // Listen for time selection changes
-        pickupTimeInput.addEventListener('change', handleTimeChange);
-        pickupTimeInput.addEventListener('input', handleTimeChange);
+    // Click outside handler - hide checkmark when clicking outside
+    document.addEventListener("click", (e) => {
+      // Check if checkmark is currently visible
+      if (!checkmarkIcon.classList.contains("hidden")) {
+        // Check if click is outside the input container and not on the checkmark
+        if (!container.contains(e.target)) {
+          // User clicked outside - confirm the date and hide checkmark
+          confirmDate();
+        }
+      }
+    });
 
-        // Checkmark click handler - confirm the time and hide checkmark
-        checkmarkIcon.addEventListener('click', (e) => {
-            e.stopPropagation(); // Prevent event bubbling
-            confirmTime();
-        });
+    // Also hide checkmark when input loses focus (blur event)
+    freshUntilInput.addEventListener("blur", (e) => {
+      // Small delay to allow checkmark click to register first
+      setTimeout(() => {
+        if (
+          !checkmarkIcon.classList.contains("hidden") &&
+          freshUntilInput.value
+        ) {
+          confirmDate();
+        }
+      }, 100);
+    });
+  }
 
-        // Click outside handler - hide checkmark when clicking outside
-        document.addEventListener('click', (e) => {
-            // Check if checkmark is currently visible
-            if (!checkmarkIcon.classList.contains('hidden')) {
-                // Check if click is outside the input container and not on the checkmark
-                if (!container.contains(e.target)) {
-                    // User clicked outside - confirm the time and hide checkmark
-                    confirmTime();
-                }
-            }
-        });
+  // Time Input Confirmation functionality
+  setupTimeInputConfirmation() {
+    const pickupTimeInput = document.getElementById("pickupTime");
+    if (!pickupTimeInput) return;
 
-        // Also hide checkmark when input loses focus (blur event)
-        pickupTimeInput.addEventListener('blur', (e) => {
-            // Small delay to allow checkmark click to register first
-            setTimeout(() => {
-                if (!checkmarkIcon.classList.contains('hidden') && pickupTimeInput.value) {
-                    confirmTime();
-                }
-            }, 100);
-        });
-    }
+    const container = pickupTimeInput.parentNode;
+    const checkmarkIcon = container.querySelector(".checkmark-icon-time");
+
+    if (!checkmarkIcon) return;
+
+    let isTimeConfirmed = false;
+    let previousValue = pickupTimeInput.value;
+
+    // Helper function to show checkmark only after time selection
+    const handleTimeChange = () => {
+      const currentValue = pickupTimeInput.value;
+
+      // If value has changed from previous, reset confirmation status
+      if (currentValue !== previousValue) {
+        isTimeConfirmed = false;
+      }
+
+      // Only show checkmark if:
+      // 1. There's a new value
+      // 2. The value has changed from previous
+      // 3. Time hasn't been confirmed yet
+      if (currentValue && currentValue !== previousValue && !isTimeConfirmed) {
+        checkmarkIcon.classList.remove("hidden");
+      }
+
+      // If value is cleared, reset everything
+      if (!currentValue) {
+        checkmarkIcon.classList.add("hidden");
+        isTimeConfirmed = false;
+      }
+
+      previousValue = currentValue;
+    };
+
+    // Helper function to confirm time and hide checkmark
+    const confirmTime = () => {
+      if (pickupTimeInput.value && !isTimeConfirmed) {
+        // Mark as confirmed
+        isTimeConfirmed = true;
+
+        // Hide the checkmark
+        checkmarkIcon.classList.add("hidden");
+
+        // Show success toast
+        this.showToast("Time confirmed successfully!", "success");
+
+        // Move focus to next input field if available
+        const nextInput = pickupTimeInput
+          .closest(".form-group")
+          .parentElement.nextElementSibling?.querySelector("input");
+        if (nextInput) {
+          setTimeout(() => nextInput.focus(), 200);
+        } else {
+          pickupTimeInput.blur(); // Remove focus from current input
+        }
+      }
+    };
+
+    // Initially hide checkmark
+    checkmarkIcon.classList.add("hidden");
+
+    // Listen for time selection changes
+    pickupTimeInput.addEventListener("change", handleTimeChange);
+    pickupTimeInput.addEventListener("input", handleTimeChange);
+
+    // Checkmark click handler - confirm the time and hide checkmark
+    checkmarkIcon.addEventListener("click", (e) => {
+      e.stopPropagation(); // Prevent event bubbling
+      confirmTime();
+    });
+
+    // Click outside handler - hide checkmark when clicking outside
+    document.addEventListener("click", (e) => {
+      // Check if checkmark is currently visible
+      if (!checkmarkIcon.classList.contains("hidden")) {
+        // Check if click is outside the input container and not on the checkmark
+        if (!container.contains(e.target)) {
+          // User clicked outside - confirm the time and hide checkmark
+          confirmTime();
+        }
+      }
+    });
+
+    // Also hide checkmark when input loses focus (blur event)
+    pickupTimeInput.addEventListener("blur", (e) => {
+      // Small delay to allow checkmark click to register first
+      setTimeout(() => {
+        if (
+          !checkmarkIcon.classList.contains("hidden") &&
+          pickupTimeInput.value
+        ) {
+          confirmTime();
+        }
+      }, 100);
+    });
+  }
 }
 
 // Additional CSS animations via JavaScript
 function addDynamicStyles() {
-    const style = document.createElement('style');
-    style.textContent = `
+  const style = document.createElement("style");
+  style.textContent = `
         @keyframes pulse {
             0% { transform: scale(1); }
             50% { transform: scale(1.05); }
@@ -1675,13 +1840,13 @@ function addDynamicStyles() {
             }
         }
     `;
-    document.head.appendChild(style);
+  document.head.appendChild(style);
 }
 
 // Initialize the application
-document.addEventListener('DOMContentLoaded', () => {
-    addDynamicStyles();
-    new ShareBiteFoodListing();
+document.addEventListener("DOMContentLoaded", () => {
+  addDynamicStyles();
+  new ShareBiteFoodListing();
 });
 
 // Service Worker registration for PWA capabilities (optional)
@@ -1701,14 +1866,14 @@ document.addEventListener('DOMContentLoaded', () => {
 window.ShareBiteFoodListing = ShareBiteFoodListing;
 
 // Clear caches and trigger SW skipWaiting for debugging updates
-window.clearShareBiteCaches = async function() {
-    if ('caches' in window) {
-        const keys = await caches.keys();
-        await Promise.all(keys.map(k => caches.delete(k)));
-        console.log('[ShareBite] All caches cleared');
-    }
-    if (navigator.serviceWorker?.controller) {
-        navigator.serviceWorker.controller.postMessage('SKIP_WAITING');
-        console.log('[ShareBite] Sent SKIP_WAITING to service worker');
-    }
+window.clearShareBiteCaches = async function () {
+  if ("caches" in window) {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((k) => caches.delete(k)));
+    console.log("[ShareBite] All caches cleared");
+  }
+  if (navigator.serviceWorker?.controller) {
+    navigator.serviceWorker.controller.postMessage("SKIP_WAITING");
+    console.log("[ShareBite] Sent SKIP_WAITING to service worker");
+  }
 };

--- a/frontend/js/script.js
+++ b/frontend/js/script.js
@@ -1,314 +1,327 @@
 // ShareBite JavaScript - Interactive Food Waste Reduction Platform
 
-  
- 
+// Theme Toggle
+const themeToggle = document.getElementById("themeToggle");
+const body = document.body;
+const themeIcon = themeToggle.querySelector("i");
 
-        // Theme Toggle
-        const themeToggle = document.getElementById('themeToggle');
-        const body = document.body;
-        const themeIcon = themeToggle.querySelector('i');
+themeToggle.addEventListener("click", () => {
+  body.classList.toggle("dark-mode");
+  if (body.classList.contains("dark-mode")) {
+    themeIcon.classList.remove("fa-moon");
+    themeIcon.classList.add("fa-sun");
+    showToast("Dark mode enabled");
+  } else {
+    themeIcon.classList.remove("fa-sun");
+    themeIcon.classList.add("fa-moon");
+    showToast("Light mode enabled");
+  }
+});
 
-        themeToggle.addEventListener('click', () => {
-            body.classList.toggle('dark-mode');
-            if (body.classList.contains('dark-mode')) {
-                themeIcon.classList.remove('fa-moon');
-                themeIcon.classList.add('fa-sun');
-                showToast('Dark mode enabled');
-            } else {
-                themeIcon.classList.remove('fa-sun');
-                themeIcon.classList.add('fa-moon');
-                showToast('Light mode enabled');
-            }
-        });
+// Notification Toggle
+const notificationBell = document.getElementById("notificationBell");
+const notificationPanel = document.getElementById("notificationPanel");
 
-        // Notification Toggle
-        const notificationBell = document.getElementById('notificationBell');
-        const notificationPanel = document.getElementById('notificationPanel');
+notificationBell.addEventListener("click", (e) => {
+  e.stopPropagation();
+  notificationPanel.classList.toggle("show");
+});
 
-        notificationBell.addEventListener('click', (e) => {
-            e.stopPropagation();
-            notificationPanel.classList.toggle('show');
-        });
+// Close notification panel when clicking outside
+document.addEventListener("click", (e) => {
+  if (!notificationBell.contains(e.target)) {
+    notificationPanel.classList.remove("show");
+  }
+});
 
-        // Close notification panel when clicking outside
-        document.addEventListener('click', (e) => {
-            if (!notificationBell.contains(e.target)) {
-                notificationPanel.classList.remove('show');
-            }
-        });
+// Clear Notifications
+const clearNotifications = document.getElementById("clearNotifications");
+const notificationList = document.getElementById("notificationList");
+const notificationBadge = document.getElementById("notificationBadge");
 
-        // Clear Notifications
-        const clearNotifications = document.getElementById('clearNotifications');
-        const notificationList = document.getElementById('notificationList');
-        const notificationBadge = document.getElementById('notificationBadge');
+clearNotifications.addEventListener("click", () => {
+  notificationList.innerHTML =
+    '<div style="padding: 2rem; text-align: center; color: var(--text-secondary);">No notifications</div>';
+  notificationBadge.textContent = "0";
+  notificationBadge.style.display = "none";
+  showToast("Notifications cleared");
+  notificationPanel.classList.remove("show");
+});
 
-        clearNotifications.addEventListener('click', () => {
-            notificationList.innerHTML = '<div style="padding: 2rem; text-align: center; color: var(--text-secondary);">No notifications</div>';
-            notificationBadge.textContent = '0';
-            notificationBadge.style.display = 'none';
-            showToast('Notifications cleared');
-            notificationPanel.classList.remove('show');
-        });
+// Role Switch
+const roleSwitch = document.getElementById("roleSwitch");
+const currentRole = document.getElementById("currentRole");
 
-        // Role Switch
-        const roleSwitch = document.getElementById('roleSwitch');
-        const currentRole = document.getElementById('currentRole');
+roleSwitch.addEventListener("click", () => {
+  if (currentRole.textContent === "Donor") {
+    currentRole.textContent = "Receiver";
+    showToast("Switched to Receiver mode");
+  } else {
+    currentRole.textContent = "Donor";
+    showToast("Switched to Donor mode");
+  }
+});
 
-        roleSwitch.addEventListener('click', () => {
-            if (currentRole.textContent === 'Donor') {
-                currentRole.textContent = 'Receiver';
-                showToast('Switched to Receiver mode');
-            } else {
-                currentRole.textContent = 'Donor';
-                showToast('Switched to Donor mode');
-            }
-        });
+// Toast Function
+function showToast(message) {
+  const toast = document.getElementById("toast");
+  toast.textContent = message;
+  toast.classList.add("show");
+  setTimeout(() => {
+    toast.classList.remove("show");
+  }, 3000);
+}
 
-        // Toast Function
-        function showToast(message) {
-            const toast = document.getElementById('toast');
-            toast.textContent = message;
-            toast.classList.add('show');
-            setTimeout(() => {
-                toast.classList.remove('show');
-            }, 3000);
-        }
-
-        // Handle window resize
-        window.addEventListener('resize', () => {
-            if (window.innerWidth > 768) {
-                navMenu.classList.remove('active');
-                menuToggle.classList.remove('active');
-            }
-        });
+// Handle window resize
+window.addEventListener("resize", () => {
+  if (window.innerWidth > 768) {
+    navMenu.classList.remove("active");
+    menuToggle.classList.remove("active");
+  }
+});
 class ShareBite {
-    constructor() {
-        this.contactEmail = 'sharebite@support.com.ng';
-        this.currentRole = 'donor';
-        this.foodListings = [];
-        this.filteredListings = [];
-        this.currentFilter = 'all';
-        this.claimedItems = this.loadClaimedItems();
-        this.notifications = this.loadNotifications();
-        
-        this.init();
-        this.initTheme(); // add theme initialization after base init
+  constructor() {
+    this.contactEmail = "sharebite@support.com.ng";
+    this.currentRole = "donor";
+    this.foodListings = [];
+    this.filteredListings = [];
+    this.currentFilter = "all";
+    this.claimedItems = this.loadClaimedItems();
+    this.notifications = this.loadNotifications();
+
+    this.init();
+    this.initTheme(); // add theme initialization after base init
+  }
+
+  init() {
+    this.setupEventListeners();
+    this.updateContactInfo();
+    this.generateSampleListings();
+    this.renderFoodListings();
+    this.setupNotificationSystem();
+    this.updateNotificationDisplay();
+    this.startAnimations();
+    this.hideLoadingOverlay();
+  }
+
+  updateContactInfo() {
+    const emailAddressElement = document.getElementById(
+      "contact-email-address"
+    );
+    const emailLinkElement = document.getElementById("contact-email-link");
+
+    if (emailAddressElement) {
+      emailAddressElement.textContent = this.contactEmail;
     }
 
-    init() {
-        this.setupEventListeners();
-        this.updateContactInfo();
-        this.generateSampleListings();
-        this.renderFoodListings();
-        this.setupNotificationSystem();
-        this.updateNotificationDisplay();
-        this.startAnimations();
-        this.hideLoadingOverlay();
+    if (emailLinkElement) {
+      emailLinkElement.href = `mailto:${this.contactEmail}`;
     }
+  }
 
-    updateContactInfo() {
-        const emailAddressElement = document.getElementById('contact-email-address');
-        const emailLinkElement = document.getElementById('contact-email-link');
+  initTheme() {
+    const stored = localStorage.getItem("sharebite-theme");
+    const prefersDark =
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const theme = stored || (prefersDark ? "dark" : "light");
+    this.applyTheme(theme);
+    this.setupThemeToggle();
+  }
 
-        if (emailAddressElement) {
-            emailAddressElement.textContent = this.contactEmail;
+  setupThemeToggle() {
+    const btn = document.getElementById("themeToggle");
+    if (!btn) return;
+    btn.addEventListener("click", () => {
+      const newTheme = document.documentElement.classList.contains("dark")
+        ? "light"
+        : "dark";
+      this.applyTheme(newTheme);
+      localStorage.setItem("sharebite-theme", newTheme);
+    });
+  }
+
+  applyTheme(theme) {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+      const icon = document.querySelector("#themeToggle i");
+      if (icon) {
+        icon.classList.remove("fa-moon");
+        icon.classList.add("fa-sun");
+      }
+    } else {
+      root.classList.remove("dark");
+      const icon = document.querySelector("#themeToggle i");
+      if (icon) {
+        icon.classList.remove("fa-sun");
+        icon.classList.add("fa-moon");
+      }
+    }
+  }
+
+  setupEventListeners() {
+    // Navigation
+    this.setupNavigation();
+
+    // Role switching
+    this.setupRoleSwitch();
+
+    // Modal functionality
+    this.setupModal();
+
+    // Form handling
+    this.setupFormHandling();
+
+    // Date input confirmation functionality
+    this.setupDateInputConfirmation();
+
+    // Time input confirmation functionality
+    this.setupTimeInputConfirmation();
+
+    // Filtering and search
+    this.setupFilteringAndSearch();
+
+    // Smooth scrolling
+    this.setupSmoothScrolling();
+
+    // Responsive navigation
+    this.setupResponsiveNav();
+
+    // Hero button interactions
+    this.setupHeroButtons();
+
+    // Statistics counter animation
+    this.setupStatsAnimation();
+
+    // Scroll effects
+    this.setupScrollEffects();
+  }
+
+  setupNavigation() {
+    const navLinks = document.querySelectorAll(".nav-link");
+    navLinks.forEach((link) => {
+      link.addEventListener("click", (e) => {
+        const href = link.getAttribute("href");
+        // Ignore .html links
+        if (href && href.endsWith(".html")) return;
+        e.preventDefault();
+        const targetId = href.substring(1);
+        const targetElement = document.getElementById(targetId);
+        if (targetElement) {
+          targetElement.scrollIntoView({ behavior: "smooth" });
         }
+      });
+    });
+  }
 
-        if (emailLinkElement) {
-            emailLinkElement.href = `mailto:${this.contactEmail}`;
-        }
+  setupRoleSwitch() {
+    const roleSwitch = document.getElementById("roleSwitch");
+    const currentRoleSpan = document.getElementById("currentRole");
+
+    roleSwitch.addEventListener("click", () => {
+      this.currentRole = this.currentRole === "donor" ? "collector" : "donor";
+      currentRoleSpan.textContent =
+        this.currentRole.charAt(0).toUpperCase() + this.currentRole.slice(1);
+
+      // Update UI based on role
+      this.updateUIForRole();
+    });
+  }
+
+  updateUIForRole() {
+    const donateBtn = document.getElementById("donateFood");
+    const findBtn = document.getElementById("findFood");
+    const addListingBtn = document.getElementById("addListingBtn");
+    const notificationBell = document.getElementById("notificationBell");
+
+    if (this.currentRole === "collector") {
+      donateBtn.innerHTML = '<i class="fas fa-search"></i> Find Food';
+      findBtn.innerHTML = '<i class="fas fa-heart"></i> Help Others';
+      addListingBtn.style.display = "none";
+
+      // Show notification bell for collectors
+      if (notificationBell) {
+        notificationBell.style.display = "block";
+      }
+    } else {
+      donateBtn.innerHTML = '<i class="fas fa-heart"></i> Donate Food';
+      findBtn.innerHTML = '<i class="fas fa-search"></i> Find Food';
+      addListingBtn.style.display = "flex";
+
+      // Hide notification bell for donors (unless they have notifications)
+      if (notificationBell && this.notifications.length === 0) {
+        notificationBell.style.display = "none";
+      }
     }
 
-    initTheme() {
-        const stored = localStorage.getItem('sharebite-theme');
-        const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-        const theme = stored || (prefersDark ? 'dark' : 'light');
-        this.applyTheme(theme);
-        this.setupThemeToggle();
-    }
+    // Re-render food listings to update claim button states
+    this.renderFoodListings();
+  }
 
-    setupThemeToggle() {
-        const btn = document.getElementById('themeToggle');
-        if (!btn) return;
-        btn.addEventListener('click', () => {
-            const newTheme = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
-            this.applyTheme(newTheme);
-            localStorage.setItem('sharebite-theme', newTheme);
-        });
-    }
-
-    applyTheme(theme) {
-        const root = document.documentElement;
-        if (theme === 'dark') {
-            root.classList.add('dark');
-            const icon = document.querySelector('#themeToggle i');
-            if (icon) { icon.classList.remove('fa-moon'); icon.classList.add('fa-sun'); }
-        } else {
-            root.classList.remove('dark');
-            const icon = document.querySelector('#themeToggle i');
-            if (icon) { icon.classList.remove('fa-sun'); icon.classList.add('fa-moon'); }
-        }
-    }
-
-    setupEventListeners() {
-        // Navigation
-        this.setupNavigation();
-        
-        // Role switching
-        this.setupRoleSwitch();
-        
-        // Modal functionality
-        this.setupModal();
-        
-        // Form handling
-        this.setupFormHandling();
-        
-        // Date input confirmation functionality
-        this.setupDateInputConfirmation();
-        
-        // Time input confirmation functionality
-        this.setupTimeInputConfirmation();
-        
-        // Filtering and search
-        this.setupFilteringAndSearch();
-        
-        // Smooth scrolling
-        this.setupSmoothScrolling();
-        
-        // Responsive navigation
-        this.setupResponsiveNav();
-        
-        // Hero button interactions
-        this.setupHeroButtons();
-        
-        // Statistics counter animation
-        this.setupStatsAnimation();
-        
-        // Scroll effects
-        this.setupScrollEffects();
-    }
-
-    setupNavigation() {
-        const navLinks = document.querySelectorAll('.nav-link');
-        navLinks.forEach(link => {
-            link.addEventListener('click', (e) => {
-                const href = link.getAttribute('href');
-                // Ignore .html links
-                if (href && href.endsWith('.html')) return;
-                e.preventDefault();
-                const targetId = href.substring(1);
-                const targetElement = document.getElementById(targetId);
-                if (targetElement) {
-                    targetElement.scrollIntoView({ behavior: 'smooth' });
-                }
-            });
-        });
-    }
-
-    setupRoleSwitch() {
-        const roleSwitch = document.getElementById('roleSwitch');
-        const currentRoleSpan = document.getElementById('currentRole');
-        
-        roleSwitch.addEventListener('click', () => {
-            this.currentRole = this.currentRole === 'donor' ? 'collector' : 'donor';
-            currentRoleSpan.textContent = this.currentRole.charAt(0).toUpperCase() + this.currentRole.slice(1);
-            
-            // Update UI based on role
-            this.updateUIForRole();
-        });
-    }
-
-    updateUIForRole() {
-        const donateBtn = document.getElementById('donateFood');
-        const findBtn = document.getElementById('findFood');
-        const addListingBtn = document.getElementById('addListingBtn');
-        const notificationBell = document.getElementById('notificationBell');
-        
-        if (this.currentRole === 'collector') {
-            donateBtn.innerHTML = '<i class="fas fa-search"></i> Find Food';
-            findBtn.innerHTML = '<i class="fas fa-heart"></i> Help Others';
-            addListingBtn.style.display = 'none';
-            
-            // Show notification bell for collectors
-            if (notificationBell) {
-                notificationBell.style.display = 'block';
-            }
-        } else {
-            donateBtn.innerHTML = '<i class="fas fa-heart"></i> Donate Food';
-            findBtn.innerHTML = '<i class="fas fa-search"></i> Find Food';
-            addListingBtn.style.display = 'flex';
-            
-            // Hide notification bell for donors (unless they have notifications)
-            if (notificationBell && this.notifications.length === 0) {
-                notificationBell.style.display = 'none';
-            }
-        }
-        
-        // Re-render food listings to update claim button states
-        this.renderFoodListings();
-    }
-
-   setupModal() {
-    const modal = document.getElementById('addListingModal');
-    const addListingBtn = document.getElementById('addListingBtn');
-    const closeModalBtn = document.querySelector('.close-modal');
-    const cancelBtn = document.getElementById('cancelForm');
+  setupModal() {
+    const modal = document.getElementById("addListingModal");
+    const addListingBtn = document.getElementById("addListingBtn");
+    const closeModalBtn = document.querySelector(".close-modal");
+    const cancelBtn = document.getElementById("cancelForm");
 
     this.currentStep = 1;
     this.totalSteps = 3;
 
-    addListingBtn.addEventListener('click', () => {
-        modal.style.display = 'block';
-        document.body.style.overflow = 'hidden';
-        this.resetFormSteps();
+    addListingBtn.addEventListener("click", () => {
+      modal.style.display = "block";
+      document.body.style.overflow = "hidden";
+      this.resetFormSteps();
     });
 
     const closeModal = () => {
-        modal.style.display = 'none';
-        document.body.style.overflow = 'auto';
-        this.resetForm();
-        this.resetFormSteps();
+      modal.style.display = "none";
+      document.body.style.overflow = "auto";
+      this.resetForm();
+      this.resetFormSteps();
     };
 
-    closeModalBtn.addEventListener('click', closeModal);
-    cancelBtn.addEventListener('click', closeModal);
-    
-    modal.addEventListener('click', (e) => {
-        if (e.target === modal) {
-            closeModal();
-        }
+    closeModalBtn.addEventListener("click", closeModal);
+    cancelBtn.addEventListener("click", closeModal);
+
+    modal.addEventListener("click", (e) => {
+      if (e.target === modal) {
+        closeModal();
+      }
     });
 
     this.setupFileUpload();
     this.setupFormNavigation();
-}
+  }
 
-setupFormNavigation() {
-    const nextBtn = document.getElementById('nextStep');
-    const prevBtn = document.getElementById('prevStep');
-    const submitBtn = document.getElementById('submitForm');
+  setupFormNavigation() {
+    const nextBtn = document.getElementById("nextStep");
+    const prevBtn = document.getElementById("prevStep");
+    const submitBtn = document.getElementById("submitForm");
 
-    nextBtn.addEventListener('click', () => {
-        if (this.validateCurrentStep()) {
-            this.goToStep(this.currentStep + 1);
-        }
+    nextBtn.addEventListener("click", () => {
+      if (this.validateCurrentStep()) {
+        this.goToStep(this.currentStep + 1);
+      }
     });
 
-    prevBtn.addEventListener('click', () => {
-        this.goToStep(this.currentStep - 1);
+    prevBtn.addEventListener("click", () => {
+      this.goToStep(this.currentStep - 1);
     });
-}
+  }
 
-goToStep(stepNumber) {
+  goToStep(stepNumber) {
     if (stepNumber < 1 || stepNumber > this.totalSteps) return;
 
-    document.querySelectorAll('.form-step').forEach(step => {
-        step.classList.remove('active');
+    document.querySelectorAll(".form-step").forEach((step) => {
+      step.classList.remove("active");
     });
 
-    const newStep = document.querySelector(`.form-step[data-step="${stepNumber}"]`);
+    const newStep = document.querySelector(
+      `.form-step[data-step="${stepNumber}"]`
+    );
     if (newStep) {
-        newStep.classList.add('active');
+      newStep.classList.add("active");
     }
 
     this.updateProgress(stepNumber);
@@ -316,226 +329,250 @@ goToStep(stepNumber) {
     this.updateNavigationButtons(stepNumber);
 
     this.currentStep = stepNumber;
-}
+  }
 
-updateProgress(stepNumber) {
-    const steps = document.querySelectorAll('.progress-step');
-    
+  updateProgress(stepNumber) {
+    const steps = document.querySelectorAll(".progress-step");
+
     steps.forEach((step, index) => {
-        const stepNum = index + 1;
-        
-        if (stepNum < stepNumber) {
-            step.classList.add('completed');
-            step.classList.remove('active');
-        } else if (stepNum === stepNumber) {
-            step.classList.add('active');
-            step.classList.remove('completed');
-        } else {
-            step.classList.remove('active', 'completed');
-        }
+      const stepNum = index + 1;
+
+      if (stepNum < stepNumber) {
+        step.classList.add("completed");
+        step.classList.remove("active");
+      } else if (stepNum === stepNumber) {
+        step.classList.add("active");
+        step.classList.remove("completed");
+      } else {
+        step.classList.remove("active", "completed");
+      }
     });
-}
+  }
 
-updateNavigationButtons(stepNumber) {
-    const nextBtn = document.getElementById('nextStep');
-    const prevBtn = document.getElementById('prevStep');
-    const submitBtn = document.getElementById('submitForm');
+  updateNavigationButtons(stepNumber) {
+    const nextBtn = document.getElementById("nextStep");
+    const prevBtn = document.getElementById("prevStep");
+    const submitBtn = document.getElementById("submitForm");
 
-    prevBtn.style.display = stepNumber === 1 ? 'none' : 'flex';
-    nextBtn.style.display = stepNumber === this.totalSteps ? 'none' : 'flex';
-    submitBtn.style.display = stepNumber === this.totalSteps ? 'flex' : 'none';
-}
+    prevBtn.style.display = stepNumber === 1 ? "none" : "flex";
+    nextBtn.style.display = stepNumber === this.totalSteps ? "none" : "flex";
+    submitBtn.style.display = stepNumber === this.totalSteps ? "flex" : "none";
+  }
 
-validateCurrentStep() {
-    const currentStepEl = document.querySelector(`.form-step[data-step="${this.currentStep}"]`);
-    const requiredInputs = currentStepEl.querySelectorAll('[required]');
-    
+  validateCurrentStep() {
+    const currentStepEl = document.querySelector(
+      `.form-step[data-step="${this.currentStep}"]`
+    );
+    const requiredInputs = currentStepEl.querySelectorAll("[required]");
+
     for (let input of requiredInputs) {
-        if (!input.value.trim()) {
-            input.focus();
-            this.showToast(`Please fill in the required field: ${input.previousElementSibling.textContent}`, 'error');
-            return false;
-        }
+      if (!input.value.trim()) {
+        input.focus();
+        this.showToast(
+          `Please fill in the required field: ${input.previousElementSibling.textContent}`,
+          "error"
+        );
+        return false;
+      }
     }
-    
-    return true;
-}
 
-resetFormSteps() {
+    return true;
+  }
+
+  resetFormSteps() {
     this.currentStep = 1;
     this.goToStep(1);
-}
+  }
 
-setupFileUpload() {
-    const fileInput = document.getElementById('photo');
-    const uploadArea = document.getElementById('photoUpload');
-    const imagePreview = document.getElementById('imagePreview');
+  setupFileUpload() {
+    const fileInput = document.getElementById("photo");
+    const uploadArea = document.getElementById("photoUpload");
+    const imagePreview = document.getElementById("imagePreview");
 
-    uploadArea.addEventListener('click', () => {
-        fileInput.click();
+    uploadArea.addEventListener("click", () => {
+      fileInput.click();
     });
 
-    uploadArea.addEventListener('dragover', (e) => {
-        e.preventDefault();
-        uploadArea.classList.add('drag-over');
+    uploadArea.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      uploadArea.classList.add("drag-over");
     });
 
-    uploadArea.addEventListener('dragleave', (e) => {
-        e.preventDefault();
-        uploadArea.classList.remove('drag-over');
+    uploadArea.addEventListener("dragleave", (e) => {
+      e.preventDefault();
+      uploadArea.classList.remove("drag-over");
     });
 
-    uploadArea.addEventListener('drop', (e) => {
-        e.preventDefault();
-        uploadArea.classList.remove('drag-over');
-        const files = e.dataTransfer.files;
-        if (files.length > 0 && files[0].type.startsWith('image/')) {
-            fileInput.files = files;
-            this.handleFileSelect(files[0]);
-        } else {
-            this.showToast('Please upload a valid image file', 'error');
-        }
+    uploadArea.addEventListener("drop", (e) => {
+      e.preventDefault();
+      uploadArea.classList.remove("drag-over");
+      const files = e.dataTransfer.files;
+      if (files.length > 0 && files[0].type.startsWith("image/")) {
+        fileInput.files = files;
+        this.handleFileSelect(files[0]);
+      } else {
+        this.showToast("Please upload a valid image file", "error");
+      }
     });
 
-    fileInput.addEventListener('change', (e) => {
-        if (e.target.files.length > 0) {
-            this.handleFileSelect(e.target.files[0]);
-        }
+    fileInput.addEventListener("change", (e) => {
+      if (e.target.files.length > 0) {
+        this.handleFileSelect(e.target.files[0]);
+      }
     });
-}
+  }
 
-handleFileSelect(file) {
-    const imagePreview = document.getElementById('imagePreview');
-    const uploadArea = document.getElementById('photoUpload');
-    
-    if (!file.type.startsWith('image/')) {
-        this.showToast('Please select an image file', 'error');
-        return;
+  handleFileSelect(file) {
+    const imagePreview = document.getElementById("imagePreview");
+    const uploadArea = document.getElementById("photoUpload");
+
+    if (!file.type.startsWith("image/")) {
+      this.showToast("Please select an image file", "error");
+      return;
     }
 
     if (file.size > 5 * 1024 * 1024) {
-        this.showToast('Image size should be less than 5MB', 'error');
-        return;
+      this.showToast("Image size should be less than 5MB", "error");
+      return;
     }
 
     const reader = new FileReader();
     reader.onload = (e) => {
-        imagePreview.innerHTML = `
+      imagePreview.innerHTML = `
             <img src="${e.target.result}" alt="Food preview">
             <button type="button" class="remove-image">
                 <i class="fas fa-times"></i>
             </button>
         `;
-        imagePreview.classList.add('active');
-        uploadArea.style.display = 'none';
+      imagePreview.classList.add("active");
+      uploadArea.style.display = "none";
 
-        // Add remove functionality
-        const removeBtn = imagePreview.querySelector('.remove-image');
-        removeBtn.addEventListener('click', () => {
-            imagePreview.innerHTML = '';
-            imagePreview.classList.remove('active');
-            uploadArea.style.display = 'block';
-            document.getElementById('photo').value = '';
-        });
+      // Add remove functionality
+      const removeBtn = imagePreview.querySelector(".remove-image");
+      removeBtn.addEventListener("click", () => {
+        imagePreview.innerHTML = "";
+        imagePreview.classList.remove("active");
+        uploadArea.style.display = "block";
+        document.getElementById("photo").value = "";
+      });
     };
     reader.readAsDataURL(file);
-}
+  }
 
+  setupFormHandling() {
+    const form = document.getElementById("listingForm");
 
-    setupFormHandling() {
-        const form = document.getElementById('listingForm');
-        
-        form.addEventListener('submit', (e) => {
-            e.preventDefault();
-            this.handleFormSubmission();
-        });
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      this.handleFormSubmission();
+    });
 
-        const freshUntilInput = document.getElementById('freshUntil');
-        const now = new Date();
-        now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
-        freshUntilInput.min = now.toISOString().slice(0, 16);
+    const freshUntilInput = document.getElementById("freshUntil");
+    const now = new Date();
+    now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
+    freshUntilInput.min = now.toISOString().slice(0, 16);
+  }
+
+  handleFormSubmission() {
+    const formData = this.getFormData();
+
+    if (this.validateFormData(formData)) {
+      this.addNewListing(formData);
+      this.showSuccessMessage();
+      this.closeModalAndReset();
+    }
+  }
+
+  getFormData() {
+    const selectedTags = [];
+    document
+      .querySelectorAll('input[name="dietary"]:checked')
+      .forEach(function (checkbox) {
+        selectedTags.push(checkbox.value);
+      });
+
+    return {
+      id: Date.now(),
+      foodType: document.getElementById("foodType").value,
+      quantity: document.getElementById("quantity").value,
+      category: document.getElementById("category").value,
+      description: document.getElementById("description").value,
+      freshUntil: document.getElementById("freshUntil").value,
+      pickupTime: document.getElementById("pickupTime").value,
+      location: document.getElementById("location").value,
+      contact: document.getElementById("contact").value,
+      photo: document.getElementById("photo").files[0],
+      createdAt: new Date(),
+      donor: "Current User",
+      dietaryTags: selectedTags,
+    };
+  }
+
+  validateFormData(data) {
+    const requiredFields = [
+      "foodType",
+      "quantity",
+      "category",
+      "freshUntil",
+      "pickupTime",
+      "location",
+      "contact",
+    ];
+
+    for (let field of requiredFields) {
+      if (!data[field] || data[field].trim() === "") {
+        this.showErrorMessage(
+          `Please fill in the ${field
+            .replace(/([A-Z])/g, " $1")
+            .toLowerCase()}.`
+        );
+        return false;
+      }
     }
 
-    handleFormSubmission() {
-        const formData = this.getFormData();
-        
-        if (this.validateFormData(formData)) {
-            this.addNewListing(formData);
-            this.showSuccessMessage();
-            this.closeModalAndReset();
-        }
+    const freshDate = new Date(data.freshUntil);
+    if (freshDate <= new Date()) {
+      this.showErrorMessage("Fresh until date must be in the future.");
+      return false;
     }
 
-    getFormData() {
-        const selectedTags = [];
-        document.querySelectorAll('input[name="dietary"]:checked').forEach(function(checkbox) {
-            selectedTags.push(checkbox.value);
-        });
+    return true;
+  }
 
-        return {
-            id: Date.now(),
-            foodType: document.getElementById('foodType').value,
-            quantity: document.getElementById('quantity').value,
-            category: document.getElementById('category').value,
-            description: document.getElementById('description').value,
-            freshUntil: document.getElementById('freshUntil').value,
-            pickupTime: document.getElementById('pickupTime').value,
-            location: document.getElementById('location').value,
-            contact: document.getElementById('contact').value,
-            photo: document.getElementById('photo').files[0],
-            createdAt: new Date(),
-            donor: 'Current User',
-            dietaryTags: selectedTags 
-        };
-    }
+  addNewListing(data) {
+    this.foodListings.unshift(data);
+    this.filterListings();
+    this.renderFoodListings();
+  }
 
-    validateFormData(data) {
-        const requiredFields = ['foodType', 'quantity', 'category', 'freshUntil', 'pickupTime', 'location', 'contact'];
-        
-        for (let field of requiredFields) {
-            if (!data[field] || data[field].trim() === '') {
-                this.showErrorMessage(`Please fill in the ${field.replace(/([A-Z])/g, ' $1').toLowerCase()}.`);
-                return false;
-            }
-        }
-        
-        const freshDate = new Date(data.freshUntil);
-        if (freshDate <= new Date()) {
-            this.showErrorMessage('Fresh until date must be in the future.');
-            return false;
-        }
-        
-        return true;
-    }
+  showSuccessMessage() {
+    this.showToast("Food listing added successfully!", "success");
+  }
 
-    addNewListing(data) {
-        this.foodListings.unshift(data);
-        this.filterListings();
-        this.renderFoodListings();
-    }
+  showErrorMessage(message) {
+    this.showToast(message, "error");
+  }
 
-    showSuccessMessage() {
-        this.showToast('Food listing added successfully!', 'success');
-    }
-
-    showErrorMessage(message) {
-        this.showToast(message, 'error');
-    }
-
-    showToast(message, type) {
-        const toast = document.createElement('div');
-        toast.className = `toast toast-${type}`;
-        toast.innerHTML = `
-            <i class="fas fa-${type === 'success' ? 'check-circle' : 'exclamation-circle'}"></i>
+  showToast(message, type) {
+    const toast = document.createElement("div");
+    toast.className = `toast toast-${type}`;
+    toast.innerHTML = `
+            <i class="fas fa-${
+              type === "success" ? "check-circle" : "exclamation-circle"
+            }"></i>
             <span>${message}</span>
         `;
-        
-        // Add toast styles
-        toast.style.cssText = `
+
+    // Add toast styles
+    toast.style.cssText = `
             position: fixed;
             top: 100px;
             right: 20px;
-            background: ${type === 'success' ? 'var(--primary-color)' : 'var(--secondary-color)'};
+            background: ${
+              type === "success"
+                ? "var(--primary-color)"
+                : "var(--secondary-color)"
+            };
             color: white;
             padding: 1rem 1.5rem;
             border-radius: var(--border-radius);
@@ -546,696 +583,758 @@ handleFileSelect(file) {
             animation: slideInRight 0.3s ease, fadeOut 0.3s ease 2.7s forwards;
             box-shadow: var(--shadow-heavy);
         `;
-        
-        document.body.appendChild(toast);
-        
-        setTimeout(() => {
-            if (toast.parentNode) {
-                toast.parentNode.removeChild(toast);
-            }
-        }, 3000);
-    }
 
-    closeModalAndReset() {
-        document.getElementById('addListingModal').style.display = 'none';
-        document.body.style.overflow = 'auto';
-        this.resetForm();
-    }
+    document.body.appendChild(toast);
 
-    resetForm() {
-        document.getElementById('listingForm').reset();
-        document.getElementById('photoUpload').innerHTML = `
+    setTimeout(() => {
+      if (toast.parentNode) {
+        toast.parentNode.removeChild(toast);
+      }
+    }, 3000);
+  }
+
+  closeModalAndReset() {
+    document.getElementById("addListingModal").style.display = "none";
+    document.body.style.overflow = "auto";
+    this.resetForm();
+  }
+
+  resetForm() {
+    document.getElementById("listingForm").reset();
+    document.getElementById("photoUpload").innerHTML = `
             <i class="fas fa-cloud-upload-alt"></i>
             <span>Click to upload or drag and drop</span>
         `;
-        
-        // Reset minimum date
-        const freshUntilInput = document.getElementById('freshUntil');
-        const now = new Date();
-        now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
-        freshUntilInput.min = now.toISOString().slice(0, 16);
-    }
 
-    // Date Input Confirmation functionality
-    setupDateInputConfirmation() {
-        const freshUntilInput = document.getElementById('freshUntil');
-        if (!freshUntilInput) return;
+    // Reset minimum date
+    const freshUntilInput = document.getElementById("freshUntil");
+    const now = new Date();
+    now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
+    freshUntilInput.min = now.toISOString().slice(0, 16);
+  }
 
-        const container = freshUntilInput.parentNode;
-        const checkmarkIcon = container.querySelector('.checkmark-icon');
+  // Date Input Confirmation functionality
+  setupDateInputConfirmation() {
+    const freshUntilInput = document.getElementById("freshUntil");
+    if (!freshUntilInput) return;
 
-        if (!checkmarkIcon) return;
+    const container = freshUntilInput.parentNode;
+    const checkmarkIcon = container.querySelector(".checkmark-icon");
 
-        let isDateConfirmed = false;
-        let previousValue = freshUntilInput.value;
+    if (!checkmarkIcon) return;
 
-        // Helper function to show checkmark only after date selection
-        const handleDateChange = () => {
-            const currentValue = freshUntilInput.value;
-            
-            // If value has changed from previous, reset confirmation status
-            if (currentValue !== previousValue) {
-                isDateConfirmed = false;
-            }
-            
-            // Only show checkmark if:
-            // 1. There's a new value
-            // 2. The value has changed from previous
-            // 3. Date hasn't been confirmed yet
-            if (currentValue && currentValue !== previousValue && !isDateConfirmed) {
-                checkmarkIcon.classList.remove('hidden');
-            }
-            
-            // If value is cleared, reset everything
-            if (!currentValue) {
-                checkmarkIcon.classList.add('hidden');
-                isDateConfirmed = false;
-            }
-            
-            previousValue = currentValue;
-        };
+    let isDateConfirmed = false;
+    let previousValue = freshUntilInput.value;
 
-        // Helper function to confirm date and hide checkmark
-        const confirmDate = () => {
-            if (freshUntilInput.value && !isDateConfirmed) {
-                // Mark as confirmed
-                isDateConfirmed = true;
-                
-                // Hide the checkmark
-                checkmarkIcon.classList.add('hidden');
-                
-                // Show success toast
-                this.showToast('Date confirmed successfully!', 'success');
-                
-                // Move focus to next input field if available
-                const nextInput = freshUntilInput.closest('.form-group').parentElement.nextElementSibling?.querySelector('input');
-                if (nextInput) {
-                    setTimeout(() => nextInput.focus(), 200);
-                } else {
-                    freshUntilInput.blur(); // Remove focus from current input
-                }
-            }
-        };
+    // Helper function to show checkmark only after date selection
+    const handleDateChange = () => {
+      const currentValue = freshUntilInput.value;
 
-        // Initially hide checkmark
-        checkmarkIcon.classList.add('hidden');
+      // If value has changed from previous, reset confirmation status
+      if (currentValue !== previousValue) {
+        isDateConfirmed = false;
+      }
 
-        // Listen for date selection changes
-        freshUntilInput.addEventListener('change', handleDateChange);
-        freshUntilInput.addEventListener('input', handleDateChange);
+      // Only show checkmark if:
+      // 1. There's a new value
+      // 2. The value has changed from previous
+      // 3. Date hasn't been confirmed yet
+      if (currentValue && currentValue !== previousValue && !isDateConfirmed) {
+        checkmarkIcon.classList.remove("hidden");
+      }
 
-        // Checkmark click handler - confirm the date and hide checkmark
-        checkmarkIcon.addEventListener('click', (e) => {
-            e.stopPropagation(); // Prevent event bubbling
-            confirmDate();
-        });
+      // If value is cleared, reset everything
+      if (!currentValue) {
+        checkmarkIcon.classList.add("hidden");
+        isDateConfirmed = false;
+      }
 
-        // Click outside handler - hide checkmark when clicking outside
-        document.addEventListener('click', (e) => {
-            // Check if checkmark is currently visible
-            if (!checkmarkIcon.classList.contains('hidden')) {
-                // Check if click is outside the input container and not on the checkmark
-                if (!container.contains(e.target)) {
-                    // User clicked outside - confirm the date and hide checkmark
-                    confirmDate();
-                }
-            }
-        });
+      previousValue = currentValue;
+    };
 
-        // Also hide checkmark when input loses focus (blur event)
-        freshUntilInput.addEventListener('blur', (e) => {
-            // Small delay to allow checkmark click to register first
-            setTimeout(() => {
-                if (!checkmarkIcon.classList.contains('hidden') && freshUntilInput.value) {
-                    confirmDate();
-                }
-            }, 100);
-        });
-    }
+    // Helper function to confirm date and hide checkmark
+    const confirmDate = () => {
+      if (freshUntilInput.value && !isDateConfirmed) {
+        // Mark as confirmed
+        isDateConfirmed = true;
 
-    // Time Input Confirmation functionality
-    setupTimeInputConfirmation() {
-        const pickupTimeInput = document.getElementById('pickupTime');
-        if (!pickupTimeInput) return;
+        // Hide the checkmark
+        checkmarkIcon.classList.add("hidden");
 
-        const container = pickupTimeInput.parentNode;
-        const checkmarkIcon = container.querySelector('.checkmark-icon-time');
+        // Show success toast
+        this.showToast("Date confirmed successfully!", "success");
 
-        if (!checkmarkIcon) return;
+        // Move focus to next input field if available
+        const nextInput = freshUntilInput
+          .closest(".form-group")
+          .parentElement.nextElementSibling?.querySelector("input");
+        if (nextInput) {
+          setTimeout(() => nextInput.focus(), 200);
+        } else {
+          freshUntilInput.blur(); // Remove focus from current input
+        }
+      }
+    };
 
-        let isTimeConfirmed = false;
-        let previousValue = pickupTimeInput.value;
+    // Initially hide checkmark
+    checkmarkIcon.classList.add("hidden");
 
-        // Helper function to show checkmark only after time selection
-        const handleTimeChange = () => {
-            const currentValue = pickupTimeInput.value;
-            
-            // If value has changed from previous, reset confirmation status
-            if (currentValue !== previousValue) {
-                isTimeConfirmed = false;
-            }
-            
-            // Only show checkmark if:
-            // 1. There's a new value
-            // 2. The value has changed from previous
-            // 3. Time hasn't been confirmed yet
-            if (currentValue && currentValue !== previousValue && !isTimeConfirmed) {
-                checkmarkIcon.classList.remove('hidden');
-            }
-            
-            // If value is cleared, reset everything
-            if (!currentValue) {
-                checkmarkIcon.classList.add('hidden');
-                isTimeConfirmed = false;
-            }
-            
-            previousValue = currentValue;
-        };
+    // Listen for date selection changes
+    freshUntilInput.addEventListener("change", handleDateChange);
+    freshUntilInput.addEventListener("input", handleDateChange);
 
-        // Helper function to confirm time and hide checkmark
-        const confirmTime = () => {
-            if (pickupTimeInput.value && !isTimeConfirmed) {
-                // Mark as confirmed
-                isTimeConfirmed = true;
-                
-                // Hide the checkmark
-                checkmarkIcon.classList.add('hidden');
-                
-                // Show success toast
-                this.showToast('Time confirmed successfully!', 'success');
-                
-                // Move focus to next input field if available
-                const nextInput = pickupTimeInput.closest('.form-group').parentElement.nextElementSibling?.querySelector('input');
-                if (nextInput) {
-                    setTimeout(() => nextInput.focus(), 200);
-                } else {
-                    pickupTimeInput.blur(); // Remove focus from current input
-                }
-            }
-        };
+    // Checkmark click handler - confirm the date and hide checkmark
+    checkmarkIcon.addEventListener("click", (e) => {
+      e.stopPropagation(); // Prevent event bubbling
+      confirmDate();
+    });
 
-        // Initially hide checkmark
-        checkmarkIcon.classList.add('hidden');
+    // Click outside handler - hide checkmark when clicking outside
+    document.addEventListener("click", (e) => {
+      // Check if checkmark is currently visible
+      if (!checkmarkIcon.classList.contains("hidden")) {
+        // Check if click is outside the input container and not on the checkmark
+        if (!container.contains(e.target)) {
+          // User clicked outside - confirm the date and hide checkmark
+          confirmDate();
+        }
+      }
+    });
 
-        // Listen for time selection changes
-        pickupTimeInput.addEventListener('change', handleTimeChange);
-        pickupTimeInput.addEventListener('input', handleTimeChange);
+    // Also hide checkmark when input loses focus (blur event)
+    freshUntilInput.addEventListener("blur", (e) => {
+      // Small delay to allow checkmark click to register first
+      setTimeout(() => {
+        if (
+          !checkmarkIcon.classList.contains("hidden") &&
+          freshUntilInput.value
+        ) {
+          confirmDate();
+        }
+      }, 100);
+    });
+  }
 
-        // Checkmark click handler - confirm the time and hide checkmark
-        checkmarkIcon.addEventListener('click', (e) => {
-            e.stopPropagation(); // Prevent event bubbling
-            confirmTime();
-        });
+  // Time Input Confirmation functionality
+  setupTimeInputConfirmation() {
+    const pickupTimeInput = document.getElementById("pickupTime");
+    if (!pickupTimeInput) return;
 
-        // Click outside handler - hide checkmark when clicking outside
-        document.addEventListener('click', (e) => {
-            // Check if checkmark is currently visible
-            if (!checkmarkIcon.classList.contains('hidden')) {
-                // Check if click is outside the input container and not on the checkmark
-                if (!container.contains(e.target)) {
-                    // User clicked outside - confirm the time and hide checkmark
-                    confirmTime();
-                }
-            }
-        });
+    const container = pickupTimeInput.parentNode;
+    const checkmarkIcon = container.querySelector(".checkmark-icon-time");
 
-        // Also hide checkmark when input loses focus (blur event)
-        pickupTimeInput.addEventListener('blur', (e) => {
-            // Small delay to allow checkmark click to register first
-            setTimeout(() => {
-                if (!checkmarkIcon.classList.contains('hidden') && pickupTimeInput.value) {
-                    confirmTime();
-                }
-            }, 100);
-        });
-    }
+    if (!checkmarkIcon) return;
 
-    setupFilteringAndSearch() {
+    let isTimeConfirmed = false;
+    let previousValue = pickupTimeInput.value;
+
+    // Helper function to show checkmark only after time selection
+    const handleTimeChange = () => {
+      const currentValue = pickupTimeInput.value;
+
+      // If value has changed from previous, reset confirmation status
+      if (currentValue !== previousValue) {
+        isTimeConfirmed = false;
+      }
+
+      // Only show checkmark if:
+      // 1. There's a new value
+      // 2. The value has changed from previous
+      // 3. Time hasn't been confirmed yet
+      if (currentValue && currentValue !== previousValue && !isTimeConfirmed) {
+        checkmarkIcon.classList.remove("hidden");
+      }
+
+      // If value is cleared, reset everything
+      if (!currentValue) {
+        checkmarkIcon.classList.add("hidden");
+        isTimeConfirmed = false;
+      }
+
+      previousValue = currentValue;
+    };
+
+    // Helper function to confirm time and hide checkmark
+    const confirmTime = () => {
+      if (pickupTimeInput.value && !isTimeConfirmed) {
+        // Mark as confirmed
+        isTimeConfirmed = true;
+
+        // Hide the checkmark
+        checkmarkIcon.classList.add("hidden");
+
+        // Show success toast
+        this.showToast("Time confirmed successfully!", "success");
+
+        // Move focus to next input field if available
+        const nextInput = pickupTimeInput
+          .closest(".form-group")
+          .parentElement.nextElementSibling?.querySelector("input");
+        if (nextInput) {
+          setTimeout(() => nextInput.focus(), 200);
+        } else {
+          pickupTimeInput.blur(); // Remove focus from current input
+        }
+      }
+    };
+
+    // Initially hide checkmark
+    checkmarkIcon.classList.add("hidden");
+
+    // Listen for time selection changes
+    pickupTimeInput.addEventListener("change", handleTimeChange);
+    pickupTimeInput.addEventListener("input", handleTimeChange);
+
+    // Checkmark click handler - confirm the time and hide checkmark
+    checkmarkIcon.addEventListener("click", (e) => {
+      e.stopPropagation(); // Prevent event bubbling
+      confirmTime();
+    });
+
+    // Click outside handler - hide checkmark when clicking outside
+    document.addEventListener("click", (e) => {
+      // Check if checkmark is currently visible
+      if (!checkmarkIcon.classList.contains("hidden")) {
+        // Check if click is outside the input container and not on the checkmark
+        if (!container.contains(e.target)) {
+          // User clicked outside - confirm the time and hide checkmark
+          confirmTime();
+        }
+      }
+    });
+
+    // Also hide checkmark when input loses focus (blur event)
+    pickupTimeInput.addEventListener("blur", (e) => {
+      // Small delay to allow checkmark click to register first
+      setTimeout(() => {
+        if (
+          !checkmarkIcon.classList.contains("hidden") &&
+          pickupTimeInput.value
+        ) {
+          confirmTime();
+        }
+      }, 100);
+    });
+  }
+
+  setupFilteringAndSearch() {
     // --- Existing Category Filter Logic ---
-    const filterBtns = document.querySelectorAll('.filter-btn');
-    filterBtns.forEach(btn => {
-        btn.addEventListener('click', () => {
-            filterBtns.forEach(b => b.classList.remove('active'));
-            btn.classList.add('active');
-            this.currentFilter = btn.getAttribute('data-filter');
-            this.filterListings();
-            this.renderFoodListings();
-        });
+    const filterBtns = document.querySelectorAll(".filter-btn");
+    filterBtns.forEach((btn) => {
+      btn.addEventListener("click", () => {
+        filterBtns.forEach((b) => b.classList.remove("active"));
+        btn.classList.add("active");
+        this.currentFilter = btn.getAttribute("data-filter");
+        this.filterListings();
+        this.renderFoodListings();
+      });
     });
 
     // --- Existing Search Input Logic ---
-    const searchInput = document.querySelector('.search-box input');
+    const searchInput = document.querySelector(".search-box input");
     let searchTimeout;
-    searchInput.addEventListener('input', (e) => {
-        clearTimeout(searchTimeout);
-        searchTimeout = setTimeout(() => {
-            this.searchQuery = e.target.value.toLowerCase();
-            this.filterListings();
-            this.renderFoodListings();
-        }, 300);
+    searchInput.addEventListener("input", (e) => {
+      clearTimeout(searchTimeout);
+      searchTimeout = setTimeout(() => {
+        this.searchQuery = e.target.value.toLowerCase();
+        this.filterListings();
+        this.renderFoodListings();
+      }, 300);
     });
 
     // --- NEW: Dropdown and Filtering Logic ---
-    const dietaryBtn = document.getElementById('dietary-filter-btn');
-    const dietaryDropdown = document.getElementById('dietary-dropdown');
-    const dietaryCheckboxes = document.querySelectorAll('input[name="dietary-filter"]');
+    const dietaryBtn = document.getElementById("dietary-filter-btn");
+    const dietaryDropdown = document.getElementById("dietary-dropdown");
+    const dietaryCheckboxes = document.querySelectorAll(
+      'input[name="dietary-filter"]'
+    );
 
     if (dietaryBtn) {
-        // Toggle dropdown visibility
-        dietaryBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            dietaryDropdown.style.display = dietaryDropdown.style.display === 'block' ? 'none' : 'block';
-            dietaryBtn.classList.toggle('active');
-        });
+      // Toggle dropdown visibility
+      dietaryBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        dietaryDropdown.style.display =
+          dietaryDropdown.style.display === "block" ? "none" : "block";
+        dietaryBtn.classList.toggle("active");
+      });
 
-        // Add event listeners to checkboxes
-        dietaryCheckboxes.forEach(checkbox => {
-            checkbox.addEventListener('change', () => {
-                this.filterListings();
-                this.renderFoodListings();
-                
-                // Update button text to show selected count
-                const selectedCount = document.querySelectorAll('input[name="dietary-filter"]:checked').length;
-                const btnSpan = dietaryBtn.querySelector('span');
-                if (selectedCount > 0) {
-                    btnSpan.textContent = `Dietary Filters (${selectedCount})`;
-                } else {
-                    btnSpan.textContent = 'Dietary Filters';
-                }
-            });
-        });
+      // Add event listeners to checkboxes
+      dietaryCheckboxes.forEach((checkbox) => {
+        checkbox.addEventListener("change", () => {
+          this.filterListings();
+          this.renderFoodListings();
 
-        // Close dropdown when clicking outside
-        document.addEventListener('click', () => {
-            if (dietaryDropdown.style.display === 'block') {
-                dietaryDropdown.style.display = 'none';
-                dietaryBtn.classList.remove('active');
-            }
+          // Update button text to show selected count
+          const selectedCount = document.querySelectorAll(
+            'input[name="dietary-filter"]:checked'
+          ).length;
+          const btnSpan = dietaryBtn.querySelector("span");
+          if (selectedCount > 0) {
+            btnSpan.textContent = `Dietary Filters (${selectedCount})`;
+          } else {
+            btnSpan.textContent = "Dietary Filters";
+          }
         });
-        
-        // Prevent closing when clicking inside the dropdown
-        dietaryDropdown.addEventListener('click', (e) => {
-            e.stopPropagation();
-        });
-    }
-}
-    filterListings() {
-        const activeDietaryFilters = [];
-        document.querySelectorAll('input[name="dietary-filter"]:checked').forEach(checkbox => {
-            activeDietaryFilters.push(checkbox.value);
-        });
+      });
 
-        this.filteredListings = this.foodListings.filter(listing => {
-            const matchesFilter = this.currentFilter === 'all' || listing.category === this.currentFilter;
-            
-            const matchesSearch = !this.searchQuery || 
-                listing.foodType.toLowerCase().includes(this.searchQuery) ||
-                listing.location.toLowerCase().includes(this.searchQuery) ||
-                listing.description.toLowerCase().includes(this.searchQuery);
-
-            const matchesDietary = activeDietaryFilters.length === 0 || 
-                (listing.dietaryTags && activeDietaryFilters.every(filter => listing.dietaryTags.includes(filter)));
-            
-            return matchesFilter && matchesSearch && matchesDietary;
-        });
-    }
-
-    setupSmoothScrolling() {
-        const scrollIndicator = document.querySelector('.scroll-indicator');
-        
-        scrollIndicator.addEventListener('click', () => {
-            document.getElementById('features').scrollIntoView({ behavior: 'smooth' });
-        });
-    }
-
-    setupResponsiveNav() {
-        const hamburger = document.querySelector('.hamburger');
-        const navMenu = document.querySelector('.nav-menu');
-        
-        hamburger.addEventListener('click', () => {
-            hamburger.classList.toggle('active');
-            navMenu.classList.toggle('active');
-        });
-    }
-
-    setupHeroButtons() {
-        const donateBtn = document.getElementById('donateFood');
-        const findBtn = document.getElementById('findFood');
-        
-        donateBtn.addEventListener('click', () => {
-            if (this.currentRole === 'donor') {
-                document.getElementById('addListingModal').style.display = 'block';
-                document.body.style.overflow = 'hidden';
-            } else {
-                document.getElementById('listings').scrollIntoView({ behavior: 'smooth' });
-            }
-        });
-        
-        findBtn.addEventListener('click', () => {
-            document.getElementById('listings').scrollIntoView({ behavior: 'smooth' });
-        });
-    }
-
-    setupStatsAnimation() {
-        const stats = document.querySelectorAll('.stat-number');
-        let animated = false;
-        
-        const animateStats = () => {
-            if (animated) return;
-            
-            stats.forEach(stat => {
-                const target = parseInt(stat.getAttribute('data-count'));
-                const duration = 2000;
-                const increment = target / (duration / 16);
-                let current = 0;
-                
-                const updateStat = () => {
-                    current += increment;
-                    if (current < target) {
-                        stat.textContent = Math.floor(current);
-                        requestAnimationFrame(updateStat);
-                    } else {
-                        stat.textContent = target;
-                    }
-                };
-                
-                updateStat();
-            });
-            
-            animated = true;
-        };
-        
-        // Trigger animation when hero section is in view
-        const observer = new IntersectionObserver((entries) => {
-            entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                    setTimeout(animateStats, 1000);
-                }
-            });
-        });
-        
-        const heroStats = document.querySelector('.hero-stats');
-        if (heroStats) {
-            observer.observe(heroStats);
+      // Close dropdown when clicking outside
+      document.addEventListener("click", () => {
+        if (dietaryDropdown.style.display === "block") {
+          dietaryDropdown.style.display = "none";
+          dietaryBtn.classList.remove("active");
         }
-    }
+      });
 
-    setupScrollEffects() {
-        // Navbar background on scroll
-        const handleScroll = () => {
-            const navbar = document.querySelector('.navbar');
-            if (!navbar) return;
-            if (window.scrollY > 50) {
-                navbar.classList.add('scrolled');
-            } else {
-                navbar.classList.remove('scrolled');
-            }
+      // Prevent closing when clicking inside the dropdown
+      dietaryDropdown.addEventListener("click", (e) => {
+        e.stopPropagation();
+      });
+    }
+  }
+  filterListings() {
+    const activeDietaryFilters = [];
+    document
+      .querySelectorAll('input[name="dietary-filter"]:checked')
+      .forEach((checkbox) => {
+        activeDietaryFilters.push(checkbox.value);
+      });
+
+    this.filteredListings = this.foodListings.filter((listing) => {
+      const matchesFilter =
+        this.currentFilter === "all" || listing.category === this.currentFilter;
+
+      const matchesSearch =
+        !this.searchQuery ||
+        listing.foodType.toLowerCase().includes(this.searchQuery) ||
+        listing.location.toLowerCase().includes(this.searchQuery) ||
+        listing.description.toLowerCase().includes(this.searchQuery);
+
+      const matchesDietary =
+        activeDietaryFilters.length === 0 ||
+        (listing.dietaryTags &&
+          activeDietaryFilters.every((filter) =>
+            listing.dietaryTags.includes(filter)
+          ));
+
+      return matchesFilter && matchesSearch && matchesDietary;
+    });
+  }
+
+  setupSmoothScrolling() {
+    const scrollIndicator = document.querySelector(".scroll-indicator");
+
+    scrollIndicator.addEventListener("click", () => {
+      document
+        .getElementById("features")
+        .scrollIntoView({ behavior: "smooth" });
+    });
+  }
+
+  setupResponsiveNav() {
+    const hamburger = document.querySelector(".hamburger");
+    const navMenu = document.querySelector(".nav-menu");
+
+    hamburger.addEventListener("click", () => {
+      hamburger.classList.toggle("active");
+      navMenu.classList.toggle("active");
+    });
+  }
+
+  setupHeroButtons() {
+    const donateBtn = document.getElementById("donateFood");
+    const findBtn = document.getElementById("findFood");
+
+    donateBtn.addEventListener("click", () => {
+      if (this.currentRole === "donor") {
+        document.getElementById("addListingModal").style.display = "block";
+        document.body.style.overflow = "hidden";
+      } else {
+        document
+          .getElementById("listings")
+          .scrollIntoView({ behavior: "smooth" });
+      }
+    });
+
+    findBtn.addEventListener("click", () => {
+      document
+        .getElementById("listings")
+        .scrollIntoView({ behavior: "smooth" });
+    });
+  }
+
+  setupStatsAnimation() {
+    const stats = document.querySelectorAll(".stat-number");
+    let animated = false;
+
+    const animateStats = () => {
+      if (animated) return;
+
+      stats.forEach((stat) => {
+        const target = parseInt(stat.getAttribute("data-count"));
+        const duration = 2000;
+        const increment = target / (duration / 16);
+        let current = 0;
+
+        const updateStat = () => {
+          current += increment;
+          if (current < target) {
+            stat.textContent = Math.floor(current);
+            requestAnimationFrame(updateStat);
+          } else {
+            stat.textContent = target;
+          }
         };
-        window.addEventListener('scroll', handleScroll);
-        // Apply initial state in case page loads scrolled (anchor/hash navigation)
-        handleScroll();
-        
-        // Animate elements on scroll
-        this.setupScrollAnimations();
-    }
 
-    setupScrollAnimations() {
-        const observerOptions = {
-            threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
-        };
-        
-        const observer = new IntersectionObserver((entries) => {
-            entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                    entry.target.classList.add('animate-in');
-                }
-            });
-        }, observerOptions);
-        
-        // Observe elements to animate
-        const elementsToAnimate = document.querySelectorAll('.feature-card, .food-card, .impact-item');
-        elementsToAnimate.forEach(el => {
-            observer.observe(el);
-        });
-    }
+        updateStat();
+      });
 
-    generateSampleListings() {
-        const sampleListings = [
-            {
-                id: 1,
-                foodType: "Fresh Pizza Margherita",
-                quantity: "8 slices",
-                category: "restaurant",
-                description: "Freshly made pizza with mozzarella, tomato sauce, and basil. Perfect condition, just from lunch service.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "18:00",
-                location: "Mario's Pizzeria, 123 Main Street",
-                contact: "+1 234-567-8900",
-                createdAt: new Date(Date.now() - 3600000),
-                donor: "Mario's Pizzeria",
-                dietaryTags: ["vegetarian"],
-                photoUrl: "https://www.allrecipes.com/thmb/2rQA_OlnLbhidei70glz6HCCYAs=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/1453815-authentic-pizza-margherita-Cynthia-Ross-4x3-1-7410c69552274163a9049342b60c22ff.jpg",
-            },
-            {
-                id: 2,
-                foodType: "Assorted Sandwiches",
-                quantity: "15 sandwiches",
-                category: "event",
-                description: "Various sandwiches including turkey, ham, and vegetarian options from corporate catering event.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "16:30",
-                location: "Downtown Conference Center",
-                contact: "events@conference.com",
-                createdAt: new Date(Date.now() - 7200000),
-                donor: "Conference Center",
-                dietaryTags: ["non-vegetarian"],
-                photoUrl: "https://bangkok.mandarinorientalshop.com/cdn/shop/files/078-_3729_2048x.jpg?v=1690709512",
+      animated = true;
+    };
 
-            },
-            {
-                id: 3,
-                foodType: "Fresh Bread & Pastries",
-                quantity: "20+ items",
-                category: "bakery",
-                description: "End-of-day fresh bread, croissants, and pastries. All baked today and still perfectly fresh.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "20:00",
-                location: "Sunrise Bakery, Oak Avenue",
-                contact: "+1 234-567-8901",
-                createdAt: new Date(Date.now() - 1800000),
-                donor: "Sunrise Bakery",
-                dietaryTags: ["dairy-free"],
-                photoUrl: "https://media.istockphoto.com/id/507021914/photo/assorted-croissand-and-bread.jpg?s=612x612&w=0&k=20&c=ruHrARluyF_yR1-hmrurOyz4sLPNeohj1zKKv8fHa8U=",
-            },
-            {
-                id: 4,
-                foodType: "Home-cooked Curry",
-                quantity: "4-6 portions",
-                category: "household",
-                description: "Vegetarian curry with rice, made too much for family dinner. Spice level: medium.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "19:00",
-                location: "Residential Area, Pine Street",
-                contact: "+1 234-567-8902",
-                createdAt: new Date(Date.now() - 900000),
-                donor: "Local Family",
-                dietaryTags: ["vegetarian", "gluten-free"],
-                photoUrl: "https://www.tasteofhome.com/wp-content/uploads/2019/04/shutterstock_610126394.jpg",
-            },
-            {
-                id: 5,
-                foodType: "Fruit & Vegetable Box",
-                quantity: "1 large box",
-                category: "restaurant",
-                description: "Fresh produce includes apples, oranges, carrots, and lettuce.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "17:00",
-                location: "Green Garden Restaurant",
-                contact: "+1 234-567-8903",
-                createdAt: new Date(Date.now() - 5400000),
-                donor: "Green Garden Restaurant",
-                dietaryTags: ["vegan"],
-                photoUrl: "https://www.firstchoiceproduce.com/wp-content/uploads/2020/03/small-produce-box.jpg",
-            },
-            {
-                id: 6,
-                foodType: "Grilled Chicken Meals",
-                quantity: "12 complete meals",
-                category: "restaurant",
-                description: "Grilled chicken with rice and vegetables. Prepared for cancelled catering order.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "18:30",
-                location: "Healthy Eats Cafe, Market Square",
-                contact: "+1 234-567-8904",
-                createdAt: new Date(Date.now() - 2700000),
-                donor: "Healthy Eats Cafe",
-                dietaryTags: ["non-vegetarian", "dairy-free"],
-                photoUrl: "https://i0.wp.com/smittenkitchen.com/wp-content/uploads/2019/05/exceptional-grilled-chicken-scaled.jpg?fit=1200%2C800&ssl=1",
-            },
-            {
-                id: 5,
-                foodType: "Fruit & Vegetable Box",
-                quantity: "1 large box",
-                category: "restaurant",
-                description: "Fresh produce includes apples, oranges, carrots, and lettuce.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "17:00",
-                location: "Green Garden Restaurant",
-                contact: "+1 234-567-8903",
-                createdAt: new Date(Date.now() - 5400000),
-                donor: "Green Garden Restaurant",
-                dietaryTags: ["vegan"],
-                photoUrl: "https://www.firstchoiceproduce.com/wp-content/uploads/2020/03/small-produce-box.jpg",
-            },
-            {
-                id: 7,
-                foodType: "Fruit & Vegetable Box",
-                quantity: "1 large box",
-                category: "restaurant",
-                description: "Fresh produce includes apples, oranges, carrots, and lettuce.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "17:00",
-                location: "Green Garden Restaurant",
-                contact: "+1 234-567-8903",
-                createdAt: new Date(Date.now() - 5400000),
-                donor: "Green Garden Restaurant",
-                dietaryTags: ["vegan"],
-                photoUrl: "https://www.firstchoiceproduce.com/wp-content/uploads/2020/03/small-produce-box.jpg",
-            },
-            {
-                id: 8,
-                foodType: "Fruit & Vegetable Box",
-                quantity: "1 large box",
-                category: "restaurant",
-                description: "Fresh produce includes apples, oranges, carrots, and lettuce.",
-                freshUntil: this.getRandomFutureDate(),
-                pickupTime: "17:00",
-                location: "Green Garden Restaurant",
-                contact: "+1 234-567-8903",
-                createdAt: new Date(Date.now() - 5400000),
-                donor: "Green Garden Restaurant",
-                dietaryTags: ["vegan"],
-                photoUrl: "https://www.firstchoiceproduce.com/wp-content/uploads/2020/03/small-produce-box.jpg",
-            },
-            
-        ];
-        
-        this.foodListings = sampleListings;
-        this.filteredListings = sampleListings;
-    }
-
-    getRandomFutureDate() {
-        const now = new Date();
-        const hours = Math.floor(Math.random() * 48) + 2; // 2 to 50 hours from now
-        const futureDate = new Date(now.getTime() + hours * 60 * 60 * 1000);
-        return futureDate.toISOString().slice(0, 16);
-    }
-
-    renderFoodListings() {
-        const foodGrid = document.getElementById('foodGrid');
-        const listingsToShow = this.filteredListings.slice(0, 6);
-        if (!foodGrid) {
-            return; 
+    // Trigger animation when hero section is in view
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setTimeout(animateStats, 1000);
         }
+      });
+    });
 
-        if (listingsToShow.length === 0) {
-            foodGrid.innerHTML = `
+    const heroStats = document.querySelector(".hero-stats");
+    if (heroStats) {
+      observer.observe(heroStats);
+    }
+  }
+
+  setupScrollEffects() {
+    // Navbar background on scroll
+    const handleScroll = () => {
+      const navbar = document.querySelector(".navbar");
+      if (!navbar) return;
+      if (window.scrollY > 50) {
+        navbar.classList.add("scrolled");
+      } else {
+        navbar.classList.remove("scrolled");
+      }
+    };
+    window.addEventListener("scroll", handleScroll);
+    // Apply initial state in case page loads scrolled (anchor/hash navigation)
+    handleScroll();
+
+    // Animate elements on scroll
+    this.setupScrollAnimations();
+  }
+
+  setupScrollAnimations() {
+    const observerOptions = {
+      threshold: 0.1,
+      rootMargin: "0px 0px -50px 0px",
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("animate-in");
+        }
+      });
+    }, observerOptions);
+
+    // Observe elements to animate
+    const elementsToAnimate = document.querySelectorAll(
+      ".feature-card, .food-card, .impact-item"
+    );
+    elementsToAnimate.forEach((el) => {
+      observer.observe(el);
+    });
+  }
+
+  generateSampleListings() {
+    const sampleListings = [
+      {
+        id: 1,
+        foodType: "Fresh Pizza Margherita",
+        quantity: "8 slices",
+        category: "restaurant",
+        description:
+          "Freshly made pizza with mozzarella, tomato sauce, and basil. Perfect condition, just from lunch service.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "18:00",
+        location: "Mario's Pizzeria, 123 Main Street",
+        contact: "+1 234-567-8900",
+        createdAt: new Date(Date.now() - 3600000),
+        donor: "Mario's Pizzeria",
+        dietaryTags: ["vegetarian"],
+        photoUrl:
+          "https://www.allrecipes.com/thmb/2rQA_OlnLbhidei70glz6HCCYAs=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/1453815-authentic-pizza-margherita-Cynthia-Ross-4x3-1-7410c69552274163a9049342b60c22ff.jpg",
+      },
+      {
+        id: 2,
+        foodType: "Assorted Sandwiches",
+        quantity: "15 sandwiches",
+        category: "event",
+        description:
+          "Various sandwiches including turkey, ham, and vegetarian options from corporate catering event.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "16:30",
+        location: "Downtown Conference Center",
+        contact: "events@conference.com",
+        createdAt: new Date(Date.now() - 7200000),
+        donor: "Conference Center",
+        dietaryTags: ["non-vegetarian"],
+        photoUrl:
+          "https://bangkok.mandarinorientalshop.com/cdn/shop/files/078-_3729_2048x.jpg?v=1690709512",
+      },
+      {
+        id: 3,
+        foodType: "Fresh Bread & Pastries",
+        quantity: "20+ items",
+        category: "bakery",
+        description:
+          "End-of-day fresh bread, croissants, and pastries. All baked today and still perfectly fresh.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "20:00",
+        location: "Sunrise Bakery, Oak Avenue",
+        contact: "+1 234-567-8901",
+        createdAt: new Date(Date.now() - 1800000),
+        donor: "Sunrise Bakery",
+        dietaryTags: ["dairy-free"],
+        photoUrl:
+          "https://media.istockphoto.com/id/507021914/photo/assorted-croissand-and-bread.jpg?s=612x612&w=0&k=20&c=ruHrARluyF_yR1-hmrurOyz4sLPNeohj1zKKv8fHa8U=",
+      },
+      {
+        id: 4,
+        foodType: "Home-cooked Curry",
+        quantity: "4-6 portions",
+        category: "household",
+        description:
+          "Vegetarian curry with rice, made too much for family dinner. Spice level: medium.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "19:00",
+        location: "Residential Area, Pine Street",
+        contact: "+1 234-567-8902",
+        createdAt: new Date(Date.now() - 900000),
+        donor: "Local Family",
+        dietaryTags: ["vegetarian", "gluten-free"],
+        photoUrl:
+          "https://www.tasteofhome.com/wp-content/uploads/2019/04/shutterstock_610126394.jpg",
+      },
+      {
+        id: 5,
+        foodType: "Fruit & Vegetable Box",
+        quantity: "1 large box",
+        category: "restaurant",
+        description:
+          "Fresh produce includes apples, oranges, carrots, and lettuce.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "17:00",
+        location: "Green Garden Restaurant",
+        contact: "+1 234-567-8903",
+        createdAt: new Date(Date.now() - 5400000),
+        donor: "Green Garden Restaurant",
+        dietaryTags: ["vegan"],
+        photoUrl:
+          "https://www.firstchoiceproduce.com/wp-content/uploads/2020/03/small-produce-box.jpg",
+      },
+      {
+        id: 6,
+        foodType: "Grilled Chicken Meals",
+        quantity: "12 complete meals",
+        category: "restaurant",
+        description:
+          "Grilled chicken with rice and vegetables. Prepared for cancelled catering order.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "18:30",
+        location: "Healthy Eats Cafe, Market Square",
+        contact: "+1 234-567-8904",
+        createdAt: new Date(Date.now() - 2700000),
+        donor: "Healthy Eats Cafe",
+        dietaryTags: ["non-vegetarian", "dairy-free"],
+        photoUrl:
+          "https://i0.wp.com/smittenkitchen.com/wp-content/uploads/2019/05/exceptional-grilled-chicken-scaled.jpg?fit=1200%2C800&ssl=1",
+      },
+      {
+        id: 5,
+        foodType: "Fruit & Vegetable Box",
+        quantity: "1 large box",
+        category: "restaurant",
+        description:
+          "Fresh produce includes apples, oranges, carrots, and lettuce.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "17:00",
+        location: "Green Garden Restaurant",
+        contact: "+1 234-567-8903",
+        createdAt: new Date(Date.now() - 5400000),
+        donor: "Green Garden Restaurant",
+        dietaryTags: ["vegan"],
+        photoUrl:
+          "https://www.firstchoiceproduce.com/wp-content/uploads/2020/03/small-produce-box.jpg",
+      },
+      {
+        id: 7,
+        foodType: "Fruit & Vegetable Box",
+        quantity: "1 large box",
+        category: "restaurant",
+        description:
+          "Fresh produce includes apples, oranges, carrots, and lettuce.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "17:00",
+        location: "Green Garden Restaurant",
+        contact: "+1 234-567-8903",
+        createdAt: new Date(Date.now() - 5400000),
+        donor: "Green Garden Restaurant",
+        dietaryTags: ["vegan"],
+        photoUrl:
+          "https://www.firstchoiceproduce.com/wp-content/uploads/2020/03/small-produce-box.jpg",
+      },
+      {
+        id: 8,
+        foodType: "Fruit & Vegetable Box",
+        quantity: "1 large box",
+        category: "restaurant",
+        description:
+          "Fresh produce includes apples, oranges, carrots, and lettuce.",
+        freshUntil: this.getRandomFutureDate(),
+        pickupTime: "17:00",
+        location: "Green Garden Restaurant",
+        contact: "+1 234-567-8903",
+        createdAt: new Date(Date.now() - 5400000),
+        donor: "Green Garden Restaurant",
+        dietaryTags: ["vegan"],
+        photoUrl:
+          "https://www.firstchoiceproduce.com/wp-content/uploads/2020/03/small-produce-box.jpg",
+      },
+    ];
+
+    this.foodListings = sampleListings;
+    this.filteredListings = sampleListings;
+  }
+
+  getRandomFutureDate() {
+    const now = new Date();
+    const hours = Math.floor(Math.random() * 48) + 2; // 2 to 50 hours from now
+    const futureDate = new Date(now.getTime() + hours * 60 * 60 * 1000);
+    return futureDate.toISOString().slice(0, 16);
+  }
+
+  renderFoodListings() {
+    const foodGrid = document.getElementById("foodGrid");
+    const listingsToShow = this.filteredListings.slice(0, 6);
+    if (!foodGrid) {
+      return;
+    }
+
+    if (listingsToShow.length === 0) {
+      foodGrid.innerHTML = `
                 <div class="no-listings">
                     <i class="fas fa-search" style="font-size: 3rem; color: var(--medium-gray); margin-bottom: 1rem;"></i>
                     <h3>No listings found</h3>
                     <p>Try adjusting your filters or search terms.</p>
                 </div>
             `;
-            return;
-        }
-
-        foodGrid.innerHTML = listingsToShow.map(listing => this.createFoodCard(listing)).join('');
-
-        // Add event listeners to food cards
-        this.setupFoodCardInteractions();
+      return;
     }
 
-    createClaimButton(listing) {
-        const isClaimed = this.claimedItems.includes(listing.id);
-        const isCollector = this.currentRole === 'collector';
-        const username = JSON.parse(localStorage.getItem('user'))?.name;
-        
-        if(username) {
-            if (isClaimed) {
-            return `
+    foodGrid.innerHTML = listingsToShow
+      .map((listing) => this.createFoodCard(listing))
+      .join("");
+
+    // Add event listeners to food cards
+    this.setupFoodCardInteractions();
+  }
+
+  createClaimButton(listing) {
+    const isClaimed = this.claimedItems.includes(listing.id);
+    const isCollector = this.currentRole === "collector";
+    const username = JSON.parse(localStorage.getItem("user"))?.name;
+
+    if (username) {
+      if (isClaimed) {
+        return `
                 <button class="claim-btn claimed" disabled>
                     <i class="fas fa-check-circle"></i> Claimed
                 </button>
             `;
-            } else if (isCollector) {
-                return `
+      } else if (isCollector) {
+        return `
                     <button class="claim-btn" data-id="${listing.id}">
                         <i class="fas fa-hand-paper"></i> Claim Food
                     </button>
                 `;
-            } else {
-                return `
+      } else {
+        return `
                     <button class="claim-btn" style="opacity: 0.5; cursor: not-allowed;" disabled>
                         <i class="fas fa-hand-paper"></i> Switch to Collector
                     </button>
                 `;
-            }
-        } else {
-            return `
+      }
+    } else {
+      return `
                 <button class="claim-btn" style="opacity: 0.5; cursor: not-allowed;" disabled>
                     <i class="fas fa-hand-paper"></i> Login to Claim
                 </button>
             `;
-        }
     }
+  }
 
-createFoodCard(listing) {
+  createFoodCard(listing) {
     const timeAgo = this.getTimeAgo(listing.createdAt);
     const freshUntil = this.formatDateTime(listing.freshUntil);
     const isClaimed = this.claimedItems.includes(listing.id);
 
     // *** MODIFIED LOGIC START ***
-    let imgSource = '';
+    let imgSource = "";
 
     if (listing.photoUrl) {
-        // 1. Use external/sample URL if provided
-        imgSource = listing.photoUrl;
-    } else if (listing.photo && typeof listing.photo === 'object' && listing.photo instanceof File) {
-        // 2. Use temporary URL for newly uploaded file objects
-        imgSource = URL.createObjectURL(listing.photo);
-    } 
+      // 1. Use external/sample URL if provided
+      imgSource = listing.photoUrl;
+    } else if (
+      listing.photo &&
+      typeof listing.photo === "object" &&
+      listing.photo instanceof File
+    ) {
+      // 2. Use temporary URL for newly uploaded file objects
+      imgSource = URL.createObjectURL(listing.photo);
+    }
     // If neither photoUrl nor a valid File object exists, imgSource remains empty.
-    
+
     // Create the image/icon HTML based on the determined source
-    const imageHTML = imgSource 
-        ? `<img src="${imgSource}" alt="${listing.foodType}">` 
-        : `<i class="fas fa-${this.getFoodIcon(listing.category)}"></i>`;
+    const imageHTML = imgSource
+      ? `<img src="${imgSource}" alt="${listing.foodType}">`
+      : `<i class="fas fa-${this.getFoodIcon(listing.category)}"></i>`;
     // *** MODIFIED LOGIC END ***
 
     // This logic generates the HTML for the tags
-    let tagsHTML = '';
+    let tagsHTML = "";
     if (listing.dietaryTags && listing.dietaryTags.length > 0) {
-        tagsHTML = `<div class="food-tags">` +
-            listing.dietaryTags.map(tag => `<span class="tag tag-${tag}">${tag}</span>`).join('') +
+      tagsHTML =
+        `<div class="food-tags">` +
+        listing.dietaryTags
+          .map((tag) => `<span class="tag tag-${tag}">${tag}</span>`)
+          .join("") +
         `</div>`;
     }
-    
+
     // The main HTML template now uses the correctly generated imageHTML
     return `
-        <div class="food-card ${isClaimed ? 'claimed' : ''}" 
+        <div class="food-card ${isClaimed ? "claimed" : ""}" 
              data-id="${listing.id}" 
-             data-tags="${listing.dietaryTags ? listing.dietaryTags.join(',') : ''}">
+             data-tags="${
+               listing.dietaryTags ? listing.dietaryTags.join(",") : ""
+             }">
             <div class="food-image">
                 ${imageHTML}
-                <div class="food-category">${this.capitalizeFirst(listing.category)}</div>
+                <div class="food-category">${this.capitalizeFirst(
+                  listing.category
+                )}</div>
             </div>
             <div class="food-details">
                 <h3 class="food-title">${listing.foodType}</h3>
                 ${tagsHTML} 
                 <p class="food-description">${listing.description}</p>
                 <div class="food-meta">
-                    <span class="quantity"><i class="fas fa-utensils"></i> ${listing.quantity}</span>
+                    <span class="quantity"><i class="fas fa-utensils"></i> ${
+                      listing.quantity
+                    }</span>
                     <span class="freshness"><i class="fas fa-clock"></i> ${freshUntil}</span>
                 </div>
                 <div class="food-location">
@@ -1252,320 +1351,366 @@ createFoodCard(listing) {
                 </div>
                 <div class="food-actions">
                     ${this.createClaimButton(listing)}
-                    <button class="contact-btn" data-contact="${listing.contact}">
+                    <!-- explicit type to avoid acting as submit and aria-label for accessibility -->
+                    <button type="button" class="contact-btn" data-contact="${
+                      listing.contact
+                    }" aria-label="Copy contact">
                         <i class="fas fa-phone"></i>
                     </button>
                 </div>
             </div>
         </div>
     `;
-}
+  }
 
+  setupFoodCardInteractions() {
+    // Claim buttons
+    const claimBtns = document.querySelectorAll(".claim-btn");
+    claimBtns.forEach((btn) => {
+      btn.addEventListener("click", (e) => {
+        const listingId = parseInt(btn.getAttribute("data-id"));
+        this.handleClaimFood(listingId);
+      });
+    });
 
-    setupFoodCardInteractions() {
-        // Claim buttons
-        const claimBtns = document.querySelectorAll('.claim-btn');
-        claimBtns.forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const listingId = parseInt(btn.getAttribute('data-id'));
-                this.handleClaimFood(listingId);
-            });
-        });
-        
-        // Contact buttons
-        const contactBtns = document.querySelectorAll('.contact-btn');
-        contactBtns.forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const contact = btn.getAttribute('data-contact');
-                this.handleContactDonor(contact);
-            });
-        });
+    // Contact buttons
+    const contactBtns = document.querySelectorAll(".contact-btn");
+    contactBtns.forEach((btn) => {
+      btn.addEventListener("click", (e) => {
+        // Prevent default and stop propagation to avoid any parent handlers
+        // or accidental form submissions that caused a visual flash.
+        e.preventDefault();
+        e.stopPropagation();
+
+        const contact = btn.getAttribute("data-contact");
+        this.handleContactDonor(contact);
+      });
+    });
+  }
+
+  handleClaimFood(listingId) {
+    const listing = this.foodListings.find((l) => l.id === listingId);
+    if (!listing) return;
+
+    // Check if already claimed
+    if (this.claimedItems.includes(listingId)) {
+      this.showToast("This item has already been claimed!", "error");
+      return;
     }
 
-    handleClaimFood(listingId) {
-        const listing = this.foodListings.find(l => l.id === listingId);
-        if (!listing) return;
-        
-        // Check if already claimed
-        if (this.claimedItems.includes(listingId)) {
-            this.showToast('This item has already been claimed!', 'error');
-            return;
+    // Show confirmation dialog
+    const confirmed = confirm(
+      `Claim "${listing.foodType}" from ${listing.donor}?\n\nPickup: ${
+        listing.location
+      }\nTime: ${this.formatTime(listing.pickupTime)}\nContact: ${
+        listing.contact
+      }`
+    );
+
+    if (confirmed) {
+      // Add to claimed items
+      this.claimedItems.push(listingId);
+      this.saveClaimedItems();
+
+      // Create notification
+      const notification = {
+        id: Date.now(),
+        listingId: listingId,
+        foodType: listing.foodType,
+        donor: listing.donor,
+        location: listing.location,
+        pickupTime: listing.pickupTime,
+        contact: listing.contact,
+        claimedAt: new Date(),
+        status: "claimed",
+      };
+
+      this.addNotification(notification);
+
+      // Update button and card appearance
+      const claimBtn = document.querySelector(`[data-id="${listingId}"]`);
+      const foodCard = document.querySelector(
+        `.food-card[data-id="${listingId}"]`
+      );
+
+      if (claimBtn) {
+        claimBtn.classList.add("claimed");
+        claimBtn.innerHTML = '<i class="fas fa-check-circle"></i> Claimed';
+        claimBtn.disabled = true;
+      }
+
+      if (foodCard) {
+        foodCard.classList.add("claimed");
+      }
+
+      // Show success message
+      this.showToast(
+        `Successfully claimed "${listing.foodType}"! Check notifications for pickup details.`,
+        "success"
+      );
+
+      // Update notification display
+      this.updateNotificationDisplay();
+    }
+  }
+
+  handleContactDonor(contact) {
+    if (!contact) return;
+
+    // Use modern Clipboard API when available
+    navigator.clipboard
+      .writeText(contact)
+      .then(() => {
+        this.showToast("Contact information copied to clipboard!", "success");
+      })
+      .catch(() => {
+        // Fallback for older browsers: use an off-screen textarea to avoid
+        // any visual reflow/scroll that previously caused a page flash.
+        const textArea = document.createElement("textarea");
+        textArea.value = contact;
+        textArea.setAttribute("aria-hidden", "true");
+        textArea.style.position = "fixed";
+        textArea.style.left = "-9999px";
+        textArea.style.top = "0";
+        document.body.appendChild(textArea);
+        textArea.select();
+        try {
+          document.execCommand("copy");
+          this.showToast("Contact information copied to clipboard!", "success");
+        } catch (err) {
+          this.showToast(
+            "Unable to copy contact information. Please copy manually.",
+            "error"
+          );
         }
-        
-        // Show confirmation dialog
-        const confirmed = confirm(`Claim "${listing.foodType}" from ${listing.donor}?\n\nPickup: ${listing.location}\nTime: ${this.formatTime(listing.pickupTime)}\nContact: ${listing.contact}`);
-        
-        if (confirmed) {
-            // Add to claimed items
-            this.claimedItems.push(listingId);
-            this.saveClaimedItems();
-            
-            // Create notification
-            const notification = {
-                id: Date.now(),
-                listingId: listingId,
-                foodType: listing.foodType,
-                donor: listing.donor,
-                location: listing.location,
-                pickupTime: listing.pickupTime,
-                contact: listing.contact,
-                claimedAt: new Date(),
-                status: 'claimed'
-            };
-            
-            this.addNotification(notification);
-            
-            // Update button and card appearance
-            const claimBtn = document.querySelector(`[data-id="${listingId}"]`);
-            const foodCard = document.querySelector(`.food-card[data-id="${listingId}"]`);
-            
-            if (claimBtn) {
-                claimBtn.classList.add('claimed');
-                claimBtn.innerHTML = '<i class="fas fa-check-circle"></i> Claimed';
-                claimBtn.disabled = true;
-            }
-            
-            if (foodCard) {
-                foodCard.classList.add('claimed');
-            }
-            
-            // Show success message
-            this.showToast(`Successfully claimed "${listing.foodType}"! Check notifications for pickup details.`, 'success');
-            
-            // Update notification display
-            this.updateNotificationDisplay();
-        }
-    }
+        document.body.removeChild(textArea);
+      });
+  }
 
-    handleContactDonor(contact) {
-        // Copy contact to clipboard
-        navigator.clipboard.writeText(contact).then(() => {
-            this.showToast('Contact information copied to clipboard!', 'success');
-        }).catch(() => {
-            // Fallback for older browsers
-            const textArea = document.createElement('textarea');
-            textArea.value = contact;
-            document.body.appendChild(textArea);
-            textArea.select();
-            document.execCommand('copy');
-            document.body.removeChild(textArea);
-            this.showToast('Contact information copied to clipboard!', 'success');
-        });
-    }
+  getFoodIcon(category) {
+    const icons = {
+      restaurant: "store",
+      household: "home",
+      bakery: "bread-slice",
+      event: "calendar-alt",
+    };
+    return icons[category] || "utensils";
+  }
 
-    getFoodIcon(category) {
-        const icons = {
-            restaurant: 'store',
-            household: 'home',
-            bakery: 'bread-slice',
-            event: 'calendar-alt'
-        };
-        return icons[category] || 'utensils';
-    }
+  capitalizeFirst(str) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  }
 
-    capitalizeFirst(str) {
-        return str.charAt(0).toUpperCase() + str.slice(1);
-    }
+  getTimeAgo(date) {
+    const now = new Date();
+    const diff = now - date;
+    const minutes = Math.floor(diff / 60000);
+    const hours = Math.floor(minutes / 60);
 
-    getTimeAgo(date) {
-        const now = new Date();
-        const diff = now - date;
-        const minutes = Math.floor(diff / 60000);
-        const hours = Math.floor(minutes / 60);
-        
-        if (minutes < 60) {
-            return `${minutes}m ago`;
-        } else if (hours < 24) {
-            return `${hours}h ago`;
-        } else {
-            const days = Math.floor(hours / 24);
-            return `${days}d ago`;
-        }
+    if (minutes < 60) {
+      return `${minutes}m ago`;
+    } else if (hours < 24) {
+      return `${hours}h ago`;
+    } else {
+      const days = Math.floor(hours / 24);
+      return `${days}d ago`;
     }
+  }
 
-    formatDateTime(dateTimeString) {
-        const date = new Date(dateTimeString);
-        const now = new Date();
-        const diff = date - now;
-        const hours = Math.floor(diff / (1000 * 60 * 60));
-        
-        if (hours < 24) {
-            return `${hours}h left`;
-        } else {
-            const days = Math.floor(hours / 24);
-            return `${days}d left`;
-        }
+  formatDateTime(dateTimeString) {
+    const date = new Date(dateTimeString);
+    const now = new Date();
+    const diff = date - now;
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+
+    if (hours < 24) {
+      return `${hours}h left`;
+    } else {
+      const days = Math.floor(hours / 24);
+      return `${days}d left`;
     }
+  }
 
-    formatTime(timeString) {
-        const [hours, minutes] = timeString.split(':');
-        const date = new Date();
-        date.setHours(hours, minutes);
-        return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-    }
+  formatTime(timeString) {
+    const [hours, minutes] = timeString.split(":");
+    const date = new Date();
+    date.setHours(hours, minutes);
+    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
 
-    startAnimations() {
-        // Add stagger animation to feature cards
-        const featureCards = document.querySelectorAll('.feature-card');
-        featureCards.forEach((card, index) => {
-            card.style.animationDelay = `${index * 0.2}s`;
-        });
-        
-        // Add floating animation to hero elements
-        this.startFloatingAnimations();
-        
-        // Add periodic pulse to CTA buttons
-        this.startButtonPulse();
-    }
+  startAnimations() {
+    // Add stagger animation to feature cards
+    const featureCards = document.querySelectorAll(".feature-card");
+    featureCards.forEach((card, index) => {
+      card.style.animationDelay = `${index * 0.2}s`;
+    });
 
-    startFloatingAnimations() {
-        const floatingElements = document.querySelectorAll('.floating-card');
-        floatingElements.forEach((element, index) => {
-            element.style.animationDelay = `${index * 0.5}s`;
-        });
-    }
+    // Add floating animation to hero elements
+    this.startFloatingAnimations();
 
-    startButtonPulse() {
-        const ctaButtons = document.querySelectorAll('.btn-primary');
-        setInterval(() => {
-            ctaButtons.forEach((btn, index) => {
-                setTimeout(() => {
-                    btn.style.animation = 'pulse 0.6s ease';
-                    setTimeout(() => {
-                        btn.style.animation = '';
-                    }, 600);
-                }, index * 200);
-            });
-        }, 10000); // Pulse every 10 seconds
-    }
+    // Add periodic pulse to CTA buttons
+    this.startButtonPulse();
+  }
 
-    hideLoadingOverlay() {
-        const loadingOverlay = document.getElementById('loadingOverlay');
+  startFloatingAnimations() {
+    const floatingElements = document.querySelectorAll(".floating-card");
+    floatingElements.forEach((element, index) => {
+      element.style.animationDelay = `${index * 0.5}s`;
+    });
+  }
+
+  startButtonPulse() {
+    const ctaButtons = document.querySelectorAll(".btn-primary");
+    setInterval(() => {
+      ctaButtons.forEach((btn, index) => {
         setTimeout(() => {
-            loadingOverlay.style.opacity = '0';
-            setTimeout(() => {
-                loadingOverlay.style.display = 'none';
-            }, 500);
-        }, 1500); // Show loading for 1.5 seconds
+          btn.style.animation = "pulse 0.6s ease";
+          setTimeout(() => {
+            btn.style.animation = "";
+          }, 600);
+        }, index * 200);
+      });
+    }, 10000); // Pulse every 10 seconds
+  }
+
+  hideLoadingOverlay() {
+    const loadingOverlay = document.getElementById("loadingOverlay");
+    setTimeout(() => {
+      loadingOverlay.style.opacity = "0";
+      setTimeout(() => {
+        loadingOverlay.style.display = "none";
+      }, 500);
+    }, 1500); // Show loading for 1.5 seconds
+  }
+
+  // Notification System Methods
+  setupNotificationSystem() {
+    const notificationBell = document.getElementById("notificationBell");
+    const notificationPanel = document.getElementById("notificationPanel");
+
+    if (!notificationBell) return;
+
+    // Show notification bell when in collector mode or when there are notifications
+    if (this.currentRole === "collector" || this.notifications.length > 0) {
+      notificationBell.style.display = "block";
     }
 
-    // Notification System Methods
-    setupNotificationSystem() {
-        const notificationBell = document.getElementById('notificationBell');
-        const notificationPanel = document.getElementById('notificationPanel');
-        
-        if (!notificationBell) return;
-        
-        // Show notification bell when in collector mode or when there are notifications
-        if (this.currentRole === 'collector' || this.notifications.length > 0) {
-            notificationBell.style.display = 'block';
-        }
-        
-        // Toggle notification panel
-        notificationBell.addEventListener('click', (e) => {
-            e.stopPropagation();
-            const isActive = notificationPanel.classList.contains('active');
-            
-            if (isActive) {
-                notificationPanel.classList.remove('active');
-                notificationBell.classList.remove('active');
-            } else {
-                notificationPanel.classList.add('active');
-                notificationBell.classList.add('active');
-            }
-        });
-        
-        // Close panel when clicking outside
-        document.addEventListener('click', (e) => {
-            if (!notificationBell.contains(e.target)) {
-                notificationPanel.classList.remove('active');
-                notificationBell.classList.remove('active');
-            }
-        });
-        
-        // Prevent panel from closing when clicking inside
-        notificationPanel.addEventListener('click', (e) => {
-            e.stopPropagation();
-        });
+    // Toggle notification panel
+    notificationBell.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const isActive = notificationPanel.classList.contains("active");
+
+      if (isActive) {
+        notificationPanel.classList.remove("active");
+        notificationBell.classList.remove("active");
+      } else {
+        notificationPanel.classList.add("active");
+        notificationBell.classList.add("active");
+      }
+    });
+
+    // Close panel when clicking outside
+    document.addEventListener("click", (e) => {
+      if (!notificationBell.contains(e.target)) {
+        notificationPanel.classList.remove("active");
+        notificationBell.classList.remove("active");
+      }
+    });
+
+    // Prevent panel from closing when clicking inside
+    notificationPanel.addEventListener("click", (e) => {
+      e.stopPropagation();
+    });
+  }
+
+  loadClaimedItems() {
+    const stored = localStorage.getItem("sharebite-claimed-items");
+    return stored ? JSON.parse(stored) : [];
+  }
+
+  saveClaimedItems() {
+    localStorage.setItem(
+      "sharebite-claimed-items",
+      JSON.stringify(this.claimedItems)
+    );
+  }
+
+  loadNotifications() {
+    const stored = localStorage.getItem("sharebite-notifications");
+    return stored ? JSON.parse(stored) : [];
+  }
+
+  saveNotifications() {
+    localStorage.setItem(
+      "sharebite-notifications",
+      JSON.stringify(this.notifications)
+    );
+  }
+
+  addNotification(notification) {
+    this.notifications.unshift(notification);
+    this.saveNotifications();
+    this.updateNotificationDisplay();
+    this.renderNotifications();
+  }
+
+  updateNotificationDisplay() {
+    const notificationBell = document.getElementById("notificationBell");
+    const notificationBadge = document.getElementById("notificationBadge");
+
+    if (!notificationBell || !notificationBadge) return;
+
+    const unreadCount = this.notifications.length;
+
+    if (unreadCount > 0) {
+      notificationBell.style.display = "block";
+      notificationBadge.style.display = "flex";
+      notificationBadge.textContent =
+        unreadCount > 99 ? "99+" : unreadCount.toString();
+    } else {
+      notificationBadge.style.display = "none";
+      // Keep bell visible if in collector mode
+      if (this.currentRole !== "collector") {
+        notificationBell.style.display = "none";
+      }
     }
-    
-    loadClaimedItems() {
-        const stored = localStorage.getItem('sharebite-claimed-items');
-        return stored ? JSON.parse(stored) : [];
-    }
-    
-    saveClaimedItems() {
-        localStorage.setItem('sharebite-claimed-items', JSON.stringify(this.claimedItems));
-    }
-    
-    loadNotifications() {
-        const stored = localStorage.getItem('sharebite-notifications');
-        return stored ? JSON.parse(stored) : [];
-    }
-    
-    saveNotifications() {
-        localStorage.setItem('sharebite-notifications', JSON.stringify(this.notifications));
-    }
-    
-    addNotification(notification) {
-        this.notifications.unshift(notification);
-        this.saveNotifications();
-        this.updateNotificationDisplay();
-        this.renderNotifications();
-    }
-    
-    updateNotificationDisplay() {
-        const notificationBell = document.getElementById('notificationBell');
-        const notificationBadge = document.getElementById('notificationBadge');
-        
-        if (!notificationBell || !notificationBadge) return;
-        
-        const unreadCount = this.notifications.length;
-        
-        if (unreadCount > 0) {
-            notificationBell.style.display = 'block';
-            notificationBadge.style.display = 'flex';
-            notificationBadge.textContent = unreadCount > 99 ? '99+' : unreadCount.toString();
-        } else {
-            notificationBadge.style.display = 'none';
-            // Keep bell visible if in collector mode
-            if (this.currentRole !== 'collector') {
-                notificationBell.style.display = 'none';
-            }
-        }
-        
-        this.renderNotifications();
-    }
-    
-    renderNotifications() {
-        const notificationList = document.getElementById('notificationList');
-        if (!notificationList) return;
-        
-        if (this.notifications.length === 0) {
-            notificationList.innerHTML = `
+
+    this.renderNotifications();
+  }
+
+  renderNotifications() {
+    const notificationList = document.getElementById("notificationList");
+    if (!notificationList) return;
+
+    if (this.notifications.length === 0) {
+      notificationList.innerHTML = `
                 <div class="no-notifications">
                     <i class="fas fa-bell-slash"></i>
                     <h4>No claimed items yet</h4>
                     <p>Start claiming food items to see them here</p>
                 </div>
             `;
-            return;
-        }
-        
-        notificationList.innerHTML = `
+      return;
+    }
+
+    notificationList.innerHTML = `
             <div class="notification-content">
-                ${this.notifications.map(notification => this.createNotificationItem(notification)).join('')}
+                ${this.notifications
+                  .map((notification) =>
+                    this.createNotificationItem(notification)
+                  )
+                  .join("")}
             </div>
         `;
-        
-        // Add event listeners for notification actions
-        this.setupNotificationActions();
-    }
-    
-    createNotificationItem(notification) {
-        const timeAgo = this.getTimeAgo(notification.claimedAt);
-        
-        return `
+
+    // Add event listeners for notification actions
+    this.setupNotificationActions();
+  }
+
+  createNotificationItem(notification) {
+    const timeAgo = this.getTimeAgo(notification.claimedAt);
+
+    return `
             <div class="notification-item" data-id="${notification.id}">
                 <div class="notification-item-header">
                     <div class="notification-item-icon">
@@ -1583,7 +1728,9 @@ createFoodCard(listing) {
                         </div>
                         <div class="notification-detail">
                             <i class="fas fa-clock"></i>
-                            <span>Pickup: ${this.formatTime(notification.pickupTime)}</span>
+                            <span>Pickup: ${this.formatTime(
+                              notification.pickupTime
+                            )}</span>
                         </div>
                         <div class="notification-detail">
                             <i class="fas fa-phone"></i>
@@ -1593,28 +1740,32 @@ createFoodCard(listing) {
                 </div>
                 <div class="notification-meta">
                     <span class="notification-time">Claimed ${timeAgo}</span>
-                    <span class="notification-status">${this.capitalizeFirst(notification.status)}</span>
+                    <span class="notification-status">${this.capitalizeFirst(
+                      notification.status
+                    )}</span>
                 </div>
             </div>
         `;
-    }
-    
-    setupNotificationActions() {
-        const notificationItems = document.querySelectorAll('.notification-item');
-        
-        notificationItems.forEach(item => {
-            item.addEventListener('click', (e) => {
-                const notificationId = parseInt(item.getAttribute('data-id'));
-                this.viewNotificationDetails(notificationId);
-            });
-        });
-    }
-    
-    viewNotificationDetails(notificationId) {
-        const notification = this.notifications.find(n => n.id === notificationId);
-        if (!notification) return;
-        
-        const details = `
+  }
+
+  setupNotificationActions() {
+    const notificationItems = document.querySelectorAll(".notification-item");
+
+    notificationItems.forEach((item) => {
+      item.addEventListener("click", (e) => {
+        const notificationId = parseInt(item.getAttribute("data-id"));
+        this.viewNotificationDetails(notificationId);
+      });
+    });
+  }
+
+  viewNotificationDetails(notificationId) {
+    const notification = this.notifications.find(
+      (n) => n.id === notificationId
+    );
+    if (!notification) return;
+
+    const details = `
 Food: ${notification.foodType}
 Donor: ${notification.donor}
 Location: ${notification.location}
@@ -1624,28 +1775,31 @@ Claimed: ${new Date(notification.claimedAt).toLocaleString()}
 
 Contact information has been copied to clipboard.
         `;
-        
-        // Copy contact to clipboard
-        navigator.clipboard.writeText(notification.contact).then(() => {
-            alert(details);
-        }).catch(() => {
-            alert(details);
-        });
-    }
-    
-    clearAllNotifications() {
-        this.notifications = [];
-        this.claimedItems = [];
-        this.saveNotifications();
-        this.saveClaimedItems();
-        this.updateNotificationDisplay();
-    }
+
+    // Copy contact to clipboard
+    navigator.clipboard
+      .writeText(notification.contact)
+      .then(() => {
+        alert(details);
+      })
+      .catch(() => {
+        alert(details);
+      });
+  }
+
+  clearAllNotifications() {
+    this.notifications = [];
+    this.claimedItems = [];
+    this.saveNotifications();
+    this.saveClaimedItems();
+    this.updateNotificationDisplay();
+  }
 }
 
 // Additional CSS animations via JavaScript
 function addDynamicStyles() {
-    const style = document.createElement('style');
-    style.textContent = `
+  const style = document.createElement("style");
+  style.textContent = `
         @keyframes pulse {
             0% { transform: scale(1); }
             50% { transform: scale(1.05); }
@@ -1727,49 +1881,51 @@ function addDynamicStyles() {
             }
         }
     `;
-    document.head.appendChild(style);
+  document.head.appendChild(style);
 }
 
 // Initialize the application
-document.addEventListener('DOMContentLoaded', () => {
-    addDynamicStyles();
-    new ShareBite();
+document.addEventListener("DOMContentLoaded", () => {
+  addDynamicStyles();
+  new ShareBite();
 });
 
 // Service Worker registration for PWA capabilities (optional)
-if ('serviceWorker' in navigator) {
-    window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/sw.js')
-            .then(registration => {
-                console.log('SW registered: ', registration);
-            })
-            .catch(registrationError => {
-                console.log('SW registration failed: ', registrationError);
-            });
-    });
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker
+      .register("/sw.js")
+      .then((registration) => {
+        console.log("SW registered: ", registration);
+      })
+      .catch((registrationError) => {
+        console.log("SW registration failed: ", registrationError);
+      });
+  });
 }
 
 // Export for potential testing or external use
 window.ShareBite = ShareBite;
 
 // Clear caches and trigger SW skipWaiting for debugging updates
-window.clearShareBiteCaches = async function() {
-    if ('caches' in window) {
-        const keys = await caches.keys();
-        await Promise.all(keys.map(k => caches.delete(k)));
-        console.log('[ShareBite] All caches cleared');
-    }
-    if (navigator.serviceWorker?.controller) {
-        navigator.serviceWorker.controller.postMessage('SKIP_WAITING');
-        console.log('[ShareBite] Sent SKIP_WAITING to service worker');
-    }
+window.clearShareBiteCaches = async function () {
+  if ("caches" in window) {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((k) => caches.delete(k)));
+    console.log("[ShareBite] All caches cleared");
+  }
+  if (navigator.serviceWorker?.controller) {
+    navigator.serviceWorker.controller.postMessage("SKIP_WAITING");
+    console.log("[ShareBite] Sent SKIP_WAITING to service worker");
+  }
 };
 
 // ===== Scroll to Top Button =====
 const scrollToTopBtn = document.getElementById("scrollToTopBtn");
 
 window.addEventListener("scroll", () => {
-  const scrollPosition = document.documentElement.scrollTop || document.body.scrollTop;
+  const scrollPosition =
+    document.documentElement.scrollTop || document.body.scrollTop;
   if (scrollPosition > 200) {
     scrollToTopBtn.classList.add("show");
   } else {
@@ -1786,85 +1942,85 @@ scrollToTopBtn.addEventListener("click", () => {
 
 // ===== Gallery Animation and Interactivity =====
 class GalleryManager {
-    constructor() {
-        this.galleryItems = document.querySelectorAll('.gallery-item');
-        this.init();
-    }
+  constructor() {
+    this.galleryItems = document.querySelectorAll(".gallery-item");
+    this.init();
+  }
 
-    init() {
-        this.setupScrollAnimation();
-        this.setupHoverEffects();
-        this.setupClickEvents();
-    }
+  init() {
+    this.setupScrollAnimation();
+    this.setupHoverEffects();
+    this.setupClickEvents();
+  }
 
-    setupScrollAnimation() {
-        const observerOptions = {
-            threshold: 0.1,
-            rootMargin: '0px 0px -100px 0px'
-        };
+  setupScrollAnimation() {
+    const observerOptions = {
+      threshold: 0.1,
+      rootMargin: "0px 0px -100px 0px",
+    };
 
-        const observer = new IntersectionObserver((entries) => {
-            entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                    entry.target.classList.add('gallery-visible');
-                }
-            });
-        }, observerOptions);
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("gallery-visible");
+        }
+      });
+    }, observerOptions);
 
-        this.galleryItems.forEach(item => {
-            observer.observe(item);
-        });
-    }
+    this.galleryItems.forEach((item) => {
+      observer.observe(item);
+    });
+  }
 
-    setupHoverEffects() {
-        this.galleryItems.forEach(item => {
-            // Add subtle parallax effect on mouse move
-            item.addEventListener('mousemove', (e) => {
-                const rect = item.getBoundingClientRect();
-                const x = e.clientX - rect.left;
-                const y = e.clientY - rect.top;
+  setupHoverEffects() {
+    this.galleryItems.forEach((item) => {
+      // Add subtle parallax effect on mouse move
+      item.addEventListener("mousemove", (e) => {
+        const rect = item.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
 
-                const centerX = rect.width / 2;
-                const centerY = rect.height / 2;
+        const centerX = rect.width / 2;
+        const centerY = rect.height / 2;
 
-                const moveX = (x - centerX) / 20;
-                const moveY = (y - centerY) / 20;
+        const moveX = (x - centerX) / 20;
+        const moveY = (y - centerY) / 20;
 
-                const img = item.querySelector('img');
-                if (img) {
-                    img.style.transform = `scale(1.1) translate(${moveX}px, ${moveY}px)`;
-                }
-            });
+        const img = item.querySelector("img");
+        if (img) {
+          img.style.transform = `scale(1.1) translate(${moveX}px, ${moveY}px)`;
+        }
+      });
 
-            item.addEventListener('mouseleave', () => {
-                const img = item.querySelector('img');
-                if (img) {
-                    img.style.transform = 'scale(1.1)';
-                }
-            });
-        });
-    }
+      item.addEventListener("mouseleave", () => {
+        const img = item.querySelector("img");
+        if (img) {
+          img.style.transform = "scale(1.1)";
+        }
+      });
+    });
+  }
 
-    setupClickEvents() {
-        this.galleryItems.forEach(item => {
-            item.addEventListener('click', () => {
-                const category = item.getAttribute('data-category');
-                const title = item.querySelector('h3').textContent;
-                const description = item.querySelector('p').textContent;
+  setupClickEvents() {
+    this.galleryItems.forEach((item) => {
+      item.addEventListener("click", () => {
+        const category = item.getAttribute("data-category");
+        const title = item.querySelector("h3").textContent;
+        const description = item.querySelector("p").textContent;
 
-                // Optional: Open lightbox or show more details
-                this.showGalleryDetail(item, title, description, category);
-            });
-        });
-    }
+        // Optional: Open lightbox or show more details
+        this.showGalleryDetail(item, title, description, category);
+      });
+    });
+  }
 
-    showGalleryDetail(item, title, description, category) {
-        // Create a simple lightbox effect
-        const imgSrc = item.querySelector('img').src;
+  showGalleryDetail(item, title, description, category) {
+    // Create a simple lightbox effect
+    const imgSrc = item.querySelector("img").src;
 
-        const lightbox = document.createElement('div');
-        lightbox.className = 'gallery-lightbox';
-        lightbox.innerHTML = `
+    const lightbox = document.createElement("div");
+    lightbox.className = "gallery-lightbox";
+    lightbox.innerHTML = `
             <div class="lightbox-overlay"></div>
             <div class="lightbox-content">
                 <button class="lightbox-close">
@@ -1883,44 +2039,44 @@ class GalleryManager {
             </div>
         `;
 
-        document.body.appendChild(lightbox);
-        document.body.style.overflow = 'hidden';
+    document.body.appendChild(lightbox);
+    document.body.style.overflow = "hidden";
 
-        // Animate in
-        setTimeout(() => {
-            lightbox.classList.add('active');
-        }, 10);
+    // Animate in
+    setTimeout(() => {
+      lightbox.classList.add("active");
+    }, 10);
 
-        // Close handlers
-        const closeBtn = lightbox.querySelector('.lightbox-close');
-        const overlay = lightbox.querySelector('.lightbox-overlay');
+    // Close handlers
+    const closeBtn = lightbox.querySelector(".lightbox-close");
+    const overlay = lightbox.querySelector(".lightbox-overlay");
 
-        const closeLightbox = () => {
-            lightbox.classList.remove('active');
-            setTimeout(() => {
-                document.body.removeChild(lightbox);
-                document.body.style.overflow = 'auto';
-            }, 300);
-        };
+    const closeLightbox = () => {
+      lightbox.classList.remove("active");
+      setTimeout(() => {
+        document.body.removeChild(lightbox);
+        document.body.style.overflow = "auto";
+      }, 300);
+    };
 
-        closeBtn.addEventListener('click', closeLightbox);
-        overlay.addEventListener('click', closeLightbox);
+    closeBtn.addEventListener("click", closeLightbox);
+    overlay.addEventListener("click", closeLightbox);
 
-        // ESC key to close
-        const escHandler = (e) => {
-            if (e.key === 'Escape') {
-                closeLightbox();
-                document.removeEventListener('keydown', escHandler);
-            }
-        };
-        document.addEventListener('keydown', escHandler);
-    }
+    // ESC key to close
+    const escHandler = (e) => {
+      if (e.key === "Escape") {
+        closeLightbox();
+        document.removeEventListener("keydown", escHandler);
+      }
+    };
+    document.addEventListener("keydown", escHandler);
+  }
 }
 
 // Add lightbox styles dynamically
 function addGalleryLightboxStyles() {
-    const style = document.createElement('style');
-    style.textContent = `
+  const style = document.createElement("style");
+  style.textContent = `
         .gallery-lightbox {
             position: fixed;
             top: 0;
@@ -2073,233 +2229,222 @@ function addGalleryLightboxStyles() {
             }
         }
     `;
-    document.head.appendChild(style);
+  document.head.appendChild(style);
 }
 
 // Initialize gallery when DOM is ready
-if (document.querySelector('.gallery-showcase')) {
-    addGalleryLightboxStyles();
-    new GalleryManager();
+if (document.querySelector(".gallery-showcase")) {
+  addGalleryLightboxStyles();
+  new GalleryManager();
 }
 
 // ===== Testimonials Carousel =====
 class TestimonialsCarousel {
-    constructor() {
-        this.carousel = document.querySelector('.testimonials-carousel');
-        if (!this.carousel) return;
+  constructor() {
+    this.carousel = document.querySelector(".testimonials-carousel");
+    if (!this.carousel) return;
 
-        this.cards = document.querySelectorAll('.testimonial-card');
-        this.dots = document.querySelectorAll('.testimonial-dot');
-        this.prevBtn = document.querySelector('.testimonial-prev');
-        this.nextBtn = document.querySelector('.testimonial-next');
+    this.cards = document.querySelectorAll(".testimonial-card");
+    this.dots = document.querySelectorAll(".testimonial-dot");
+    this.prevBtn = document.querySelector(".testimonial-prev");
+    this.nextBtn = document.querySelector(".testimonial-next");
 
-        this.currentIndex = 0;
+    this.currentIndex = 0;
+    this.isAnimating = false;
+    this.autoPlayInterval = null;
+
+    this.init();
+  }
+
+  init() {
+    this.setupNavigation();
+    this.setupDots();
+    this.setupKeyboardNavigation();
+    this.setupTouchSwipe();
+    this.startAutoPlay();
+    this.animateStats();
+    this.pauseOnHover();
+  }
+
+  setupNavigation() {
+    this.prevBtn.addEventListener("click", () => this.goToPrevious());
+    this.nextBtn.addEventListener("click", () => this.goToNext());
+  }
+
+  setupDots() {
+    this.dots.forEach((dot, index) => {
+      dot.addEventListener("click", () => {
+        this.goToSlide(index);
+      });
+    });
+  }
+
+  setupKeyboardNavigation() {
+    document.addEventListener("keydown", (e) => {
+      if (!this.isInViewport()) return;
+
+      if (e.key === "ArrowLeft") {
+        this.goToPrevious();
+      } else if (e.key === "ArrowRight") {
+        this.goToNext();
+      }
+    });
+  }
+
+  setupTouchSwipe() {
+    let touchStartX = 0;
+    let touchEndX = 0;
+
+    this.carousel.addEventListener("touchstart", (e) => {
+      touchStartX = e.changedTouches[0].screenX;
+    });
+
+    this.carousel.addEventListener("touchend", (e) => {
+      touchEndX = e.changedTouches[0].screenX;
+      this.handleSwipe(touchStartX, touchEndX);
+    });
+  }
+
+  handleSwipe(startX, endX) {
+    const threshold = 50;
+    const diff = startX - endX;
+
+    if (Math.abs(diff) > threshold) {
+      if (diff > 0) {
+        this.goToNext();
+      } else {
+        this.goToPrevious();
+      }
+    }
+  }
+
+  goToNext() {
+    if (this.isAnimating) return;
+
+    const nextIndex = (this.currentIndex + 1) % this.cards.length;
+    this.goToSlide(nextIndex);
+  }
+
+  goToPrevious() {
+    if (this.isAnimating) return;
+
+    const prevIndex =
+      (this.currentIndex - 1 + this.cards.length) % this.cards.length;
+    this.goToSlide(prevIndex);
+  }
+
+  goToSlide(index) {
+    if (this.isAnimating || index === this.currentIndex) return;
+
+    this.isAnimating = true;
+    this.stopAutoPlay();
+
+    // Remove all active classes
+    this.cards.forEach((card) => {
+      card.classList.remove("active", "prev");
+    });
+
+    this.dots.forEach((dot) => {
+      dot.classList.remove("active");
+    });
+
+    // Set previous card
+    this.cards[this.currentIndex].classList.add("prev");
+
+    // Set active card
+    setTimeout(() => {
+      this.cards[index].classList.add("active");
+      this.dots[index].classList.add("active");
+      this.currentIndex = index;
+
+      setTimeout(() => {
         this.isAnimating = false;
-        this.autoPlayInterval = null;
-
-        this.init();
-    }
-
-    init() {
-        this.setupNavigation();
-        this.setupDots();
-        this.setupKeyboardNavigation();
-        this.setupTouchSwipe();
         this.startAutoPlay();
-        this.animateStats();
-        this.pauseOnHover();
+      }, 600);
+    }, 50);
+  }
+
+  startAutoPlay() {
+    this.stopAutoPlay();
+    this.autoPlayInterval = setInterval(() => {
+      this.goToNext();
+    }, 5000); // Change slide every 5 seconds
+  }
+
+  stopAutoPlay() {
+    if (this.autoPlayInterval) {
+      clearInterval(this.autoPlayInterval);
+      this.autoPlayInterval = null;
     }
+  }
 
-    setupNavigation() {
-        this.prevBtn.addEventListener('click', () => this.goToPrevious());
-        this.nextBtn.addEventListener('click', () => this.goToNext());
-    }
+  isInViewport() {
+    const rect = this.carousel.getBoundingClientRect();
+    return (
+      rect.top >= 0 &&
+      rect.left >= 0 &&
+      rect.bottom <=
+        (window.innerHeight || document.documentElement.clientHeight) &&
+      rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+    );
+  }
 
-    setupDots() {
-        this.dots.forEach((dot, index) => {
-            dot.addEventListener('click', () => {
-                this.goToSlide(index);
-            });
-        });
-    }
+  animateStats() {
+    const statNumbers = document.querySelectorAll(
+      ".testimonial-stat-number[data-target]"
+    );
 
-    setupKeyboardNavigation() {
-        document.addEventListener('keydown', (e) => {
-            if (!this.isInViewport()) return;
+    const observerOptions = {
+      threshold: 0.5,
+    };
 
-            if (e.key === 'ArrowLeft') {
-                this.goToPrevious();
-            } else if (e.key === 'ArrowRight') {
-                this.goToNext();
-            }
-        });
-    }
-
-    setupTouchSwipe() {
-        let touchStartX = 0;
-        let touchEndX = 0;
-
-        this.carousel.addEventListener('touchstart', (e) => {
-            touchStartX = e.changedTouches[0].screenX;
-        });
-
-        this.carousel.addEventListener('touchend', (e) => {
-            touchEndX = e.changedTouches[0].screenX;
-            this.handleSwipe(touchStartX, touchEndX);
-        });
-    }
-
-    handleSwipe(startX, endX) {
-        const threshold = 50;
-        const diff = startX - endX;
-
-        if (Math.abs(diff) > threshold) {
-            if (diff > 0) {
-                this.goToNext();
-            } else {
-                this.goToPrevious();
-            }
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (
+          entry.isIntersecting &&
+          !entry.target.classList.contains("animated")
+        ) {
+          this.animateNumber(entry.target);
+          entry.target.classList.add("animated");
         }
-    }
+      });
+    }, observerOptions);
 
-    goToNext() {
-        if (this.isAnimating) return;
+    statNumbers.forEach((stat) => observer.observe(stat));
+  }
 
-        const nextIndex = (this.currentIndex + 1) % this.cards.length;
-        this.goToSlide(nextIndex);
-    }
+  animateNumber(element) {
+    const target = parseInt(element.getAttribute("data-target"));
+    const duration = 2000;
+    const increment = target / (duration / 16);
+    let current = 0;
 
-    goToPrevious() {
-        if (this.isAnimating) return;
+    const updateNumber = () => {
+      current += increment;
+      if (current < target) {
+        element.textContent = Math.floor(current);
+        requestAnimationFrame(updateNumber);
+      } else {
+        element.textContent = target + "+";
+      }
+    };
 
-        const prevIndex = (this.currentIndex - 1 + this.cards.length) % this.cards.length;
-        this.goToSlide(prevIndex);
-    }
+    updateNumber();
+  }
 
-    goToSlide(index) {
-        if (this.isAnimating || index === this.currentIndex) return;
+  // Pause autoplay when user hovers over carousel
+  pauseOnHover() {
+    this.carousel.addEventListener("mouseenter", () => {
+      this.stopAutoPlay();
+    });
 
-        this.isAnimating = true;
-        this.stopAutoPlay();
-
-        // Remove all active classes
-        this.cards.forEach(card => {
-            card.classList.remove('active', 'prev');
-        });
-
-        this.dots.forEach(dot => {
-            dot.classList.remove('active');
-        });
-
-        // Set previous card
-        this.cards[this.currentIndex].classList.add('prev');
-
-        // Set active card
-        setTimeout(() => {
-            this.cards[index].classList.add('active');
-            this.dots[index].classList.add('active');
-            this.currentIndex = index;
-
-            setTimeout(() => {
-                this.isAnimating = false;
-                this.startAutoPlay();
-            }, 600);
-        }, 50);
-    }
-
-    startAutoPlay() {
-        this.stopAutoPlay();
-        this.autoPlayInterval = setInterval(() => {
-            this.goToNext();
-        }, 5000); // Change slide every 5 seconds
-    }
-
-    stopAutoPlay() {
-        if (this.autoPlayInterval) {
-            clearInterval(this.autoPlayInterval);
-            this.autoPlayInterval = null;
-        }
-    }
-
-    isInViewport() {
-        const rect = this.carousel.getBoundingClientRect();
-        return (
-            rect.top >= 0 &&
-            rect.left >= 0 &&
-            rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-            rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-        );
-    }
-
-    animateStats() {
-        const statNumbers = document.querySelectorAll('.testimonial-stat-number[data-target]');
-
-        const observerOptions = {
-            threshold: 0.5
-        };
-
-        const observer = new IntersectionObserver((entries) => {
-            entries.forEach(entry => {
-                if (entry.isIntersecting && !entry.target.classList.contains('animated')) {
-                    this.animateNumber(entry.target);
-                    entry.target.classList.add('animated');
-                }
-            });
-        }, observerOptions);
-
-        statNumbers.forEach(stat => observer.observe(stat));
-    }
-
-    animateNumber(element) {
-        const target = parseInt(element.getAttribute('data-target'));
-        const duration = 2000;
-        const increment = target / (duration / 16);
-        let current = 0;
-
-        const updateNumber = () => {
-            current += increment;
-            if (current < target) {
-                element.textContent = Math.floor(current);
-                requestAnimationFrame(updateNumber);
-            } else {
-                element.textContent = target + '+';
-            }
-        };
-
-        updateNumber();
-    }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    
-    // Pause autoplay when user hovers over carousel
-    pauseOnHover() {
-        this.carousel.addEventListener('mouseenter', () => {
-            this.stopAutoPlay();
-        });
-
-        this.carousel.addEventListener('mouseleave', () => {
-            this.startAutoPlay();
-        });
-    }
+    this.carousel.addEventListener("mouseleave", () => {
+      this.startAutoPlay();
+    });
+  }
 }
 
 // Initialize testimonials carousel
-if (document.querySelector('.testimonials-section')) {
-    new TestimonialsCarousel();
+if (document.querySelector(".testimonials-section")) {
+  new TestimonialsCarousel();
 }


### PR DESCRIPTION
1. Prevent the brief green/page flash when clicking the Contact button by preventing default/propagation and explicitly using [type="button"]. Also improve clipboard handling (async Clipboard API + off‑screen textarea fallback) so the “Contact information copied to clipboard!” toast shows reliably without visual reflow.