### PR TITLE
Fix: make Cancel and Previous buttons visible without hover

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1199,10 +1199,11 @@ body.dark .profile-menu-item:hover {
 }
 
 .btn-secondary {
-    background: transparent;
-    color: white;
-    border: 2px solid white;
+    background: white;
+    color: var(--primary-color);
+    border: 2px solid var(--primary-color);
 }
+
 
 .btn-secondary:hover {
     background: white;


### PR DESCRIPTION
### What was the issue?
The Cancel and Previous buttons in the Add Listing modal were not visible unless hovered, which caused usability issues.

### What did I change?
- Updated secondary button styles so the buttons are visible by default.
- Preserved existing hover effects.

### Result
Buttons are now clearly visible without requiring hover.

Fixes #345
