### PR TITLE
Fix contact information validation on home page form

### DIFF
--- a/frontend/js/script.js
+++ b/frontend/js/script.js
@@ -356,9 +356,43 @@ validateCurrentStep() {
             this.showToast(`Please fill in the required field: ${input.previousElementSibling.textContent}`, 'error');
             return false;
         }
+        // Special validation for contact information
+        if (input.id === 'contact') {
+            if (!this.validateContactInfo(input.value.trim())) {
+                input.focus();
+                this.showToast('Please enter a valid email address or phone number', 'error');
+                return false;
+            }
+        }
     }
-    
     return true;
+}
+
+validateContactInfo(contact) {
+    // Email regex
+    if(!contact) return false;
+    const emailPattern = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+    // Email check
+    if (emailPattern.test(contact)) {
+        return true;
+    }
+
+    // Phone structure: optional '+' followed by digits only
+    const phonePattern = /^\+?\d+$/;
+
+    if (!phonePattern.test(contact)) {
+        return false;
+    }
+
+    // With country code
+    if (contact.startsWith('+')) {
+        const digitCount = contact.length - 1; // exclude '+'
+        return digitCount >= 11 && digitCount <= 13;
+    }
+
+    // Without country code
+    return contact.length === 10;
 }
 
 resetFormSteps() {


### PR DESCRIPTION
This PR fixes validation issues in the home page form where invalid phone numbers could be submitted.

### Changes
- Enforces proper validation for the Contact Information field
- Allows only:
  - Valid email addresses, or
  - Phone numbers with:
    - Exactly 10 digits (without country code), or
    - A leading `+` followed by 11–13 digits (with country code)
- Prevents submission of short, incorrectly formatted, or non-numeric phone numbers

This improves data correctness and ensures consistent validation behaviour across forms.

Fixes #374 
