### PR TITLE
Fix quantity field validation on home page form

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -313,7 +313,7 @@
               <div class="form-group">
                 <label for="quantity">Quantity *</label>
                 <input
-                  type="text"
+                  type="number"
                   id="quantity"
                   required
                   placeholder="e.g., 10 portions"

--- a/frontend/js/foodlisting.js
+++ b/frontend/js/foodlisting.js
@@ -194,6 +194,12 @@ setupFormNavigation() {
     const prevBtn = document.getElementById('prevStep');
     const submitBtn = document.getElementById('submitForm');
 
+    // If the main `script.js` ShareBite class is present on the page,
+    // duplicate listeners that can bypass validation logic.
+    if (window.ShareBite) {
+        return;
+    }
+
     nextBtn.addEventListener('click', () => {
         if (this.validateCurrentStep()) {
             this.goToStep(this.currentStep + 1);

--- a/frontend/js/script.js
+++ b/frontend/js/script.js
@@ -358,6 +358,17 @@ validateCurrentStep() {
             this.showToast(`Please fill in the required field: ${input.previousElementSibling.textContent}`, 'error');
             return false;
         }
+
+        //Special validation for quantity
+        if (input.id === 'quantity') {
+            const quantity = parseInt(input.value.trim());
+            if (isNaN(quantity) || quantity <= 0) {
+                input.focus();
+                this.showToast('Please enter a valid quantity greater than 0', 'error');
+                return false;
+            }
+        }
+        
         // Special validation for contact information
         if (input.id === 'contact') {
             if (!this.validateContactInfo(input.value.trim())) {


### PR DESCRIPTION
This PR fixes validation issues in the home page form where the quantity field accepted invalid input.

### Changes
- Restricts the quantity field to positive integers only
- Prevents submission of zero, negative values, decimals, or non-numeric input

This improves data correctness and form reliability.

Fixes #375 
