### PR TITLE
Fix: Restore .env.example and ensure .env is ignored

### DIFF
--- a/backend/src/.env.example
+++ b/backend/src/.env.example
@@ -1,0 +1,7 @@
+MONGO_URI="Your MongoDB Atlas URI"
+JWT_SECRET=devsecret-change-me
+
+# Rate limiter configuration
+RATE_LIMIT_WINDOW_MS=900000 # 15 minutes in milliseconds
+RATE_LIMIT_MAX=100 # Max requests per window
+AUTH_RATE_LIMIT_MAX=5 # Max requests per window for auth routes


### PR DESCRIPTION
### Description
I noticed that `.env.example` is currently missing from the main branch. This likely happened during a previous merge.

Without this file, new contributors (myself included) cannot easily see which environment variables are required to run the project locally.

### Changes
- Created a new `.env.example` file with standard placeholder values.
- Verified `.gitignore` configuration to ensure local secrets aren't tracked.

### Importance
This is critical for onboarding new developers. Restoring this ensures the setup guide works as expected for anyone forking the repo.