### PR TITLE
Auto-update copyright year on footer and license pages

### DIFF
--- a/frontend/License.html
+++ b/frontend/License.html
@@ -691,7 +691,7 @@ SOFTWARE.</div>
                 </div>
 
                 <div class="copyright-notice">
-                    <i class="fas fa-copyright"></i> Copyright (c) 2025 Angela Bera - All Rights Reserved
+                    <i class="fas fa-copyright"></i> Copyright (c) <span class="current-year"></span> Angela Bera - All Rights Reserved
                 </div>
             </div>
         </div>
@@ -746,8 +746,17 @@ SOFTWARE.</div>
         </div>
         <div class="footer-bottom">
             <p class="footer-credit">Made with 💚 by Angela Bera</p>
-            <p>&copy; 2025 ShareBite. All rights reserved. <a href="License.html">License</a></p>
+            <p>&copy; <span class="current-year"></span> ShareBite. All rights reserved. <a href="License.html">License</a></p>
         </div>
     </footer>
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            const yearSpans = document.querySelectorAll(".current-year");yearSpans.forEach(span => {
+                span.textContent = new Date().getFullYear();
+            });
+        });
+    </script>
+
+
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1029,12 +1029,13 @@
 
   <!-- Footer Bottom -->
   <div class="footer-bottom">
-    <p>Made with 💚 by <strong>Angela Bera</strong></p>
-    <p>
-      © 2025 ShareBite. All rights reserved · 
-      <a href="License.html">License</a>
-    </p>
-  </div>
+  <p>Made with 💚 by <strong>Angela Bera</strong></p>
+  <p>
+    © <span id="current-year"></span> ShareBite. All rights reserved ·
+    <a href="License.html">License</a>
+  </p>
+</div>
+
 </footer>
 
 
@@ -1066,6 +1067,15 @@
     <script src="js/script.js"></script>
     <script src="js/api.js"></script>
     <script src="js/foodlisting.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        const yearSpan = document.getElementById("current-year");
+        if (yearSpan) {
+          yearSpan.textContent = new Date().getFullYear();
+        }
+      });
+    </script>
+
    
   <!-- ShareBite Chatbot is lazy-loaded via js/script.js -->
   </body>


### PR DESCRIPTION

## Changes included
- Footer on `index.html` updated to use a dynamic year.
- All copyright notices on `License.html` updated to use the same dynamic mechanism.
- Multiple year elements on the same page now handled correctly using `class="current-year"`.
- Added inline JavaScript to auto-update the year; works on all pages with footers or copyright notices.

## Important Notes
- **MIT License text remains completely unchanged.**
- No backend/API code was modified.

## Benefits
- Ensures the website always displays the current year automatically.
- Clean, maintainable, and safe
