### PR TITLE
Fix password toggle icon alignment and normalize input height

### DIFF
--- a/frontend/login.html
+++ b/frontend/login.html
@@ -215,10 +215,22 @@
         font-size: 1rem;
         transition: all 0.3s;
       }
+   .password-wrapper {
+  position: relative;
+  width: 100%;
+  height: 48px; /* lock height */
+}
+
+      .password-wrapper input {
+        padding-right: 2.5rem;
+      }
+
+
 
       .toggle-password {
         position: absolute;
-        top: 72%;
+        top: 50%;
+        transform: translateY(-50%);
         right: 1rem;
         transform: translateY(-50%);
         background: none;
@@ -392,6 +404,7 @@
         </div>
         <div class="form-group">
           <label for="password">Password</label>
+          <div class="password-wrapper">
           <input
             type="password"
             id="password"
@@ -422,6 +435,7 @@
               <circle cx="12" cy="12" r="3"></circle>
             </svg>
           </button>
+          </div>
         </div>
         <div class="form-options">
           <a href="forgotpassword.html" class="forgot-password-link"


### PR DESCRIPTION
# Pull Request

## Summary
Fixes the misalignment of the password visibility (eye) icon when the password validation message appears, ensuring a consistent and polished login UI.

---

## Type of Change
- [x] 🐛 Bug fix
- [x] 🎨 UI / UX improvement

--- 
Issue
- Closes #477 

---

## What Was Changed
- Wrapped the password input and toggle icon in a dedicated container to isolate layout changes
- Anchored the password visibility icon to the input field so it remains vertically centered
- Normalized the password input height to maintain visual consistency with other form fields

---

## Screenshots / Demo (Required for UI changes)
BEFORE: 
<img width="490" height="438" alt="Screenshot 2026-01-14 190208" src="https://github.com/user-attachments/assets/fe84fada-153b-4c3b-a63b-cd4a43ba8fb8" />

AFTER:

<img width="497" height="554" alt="Screenshot 2026-01-15 201732" src="https://github.com/user-attachments/assets/c699b0dd-4c08-40ba-9ed4-6feddf7d0e35" />


---

## How to Test
1. Open `index.html` in a browser
2. Navigate to the Login page
3. Start typing a password with fewer than 6 characters
4. Observe the validation message
5. Verify that the password visibility icon remains centered and the layout does not shift

---

## UI / UX Checklist
- [x] Responsive on desktop
- [x] Responsive on tablet
- [x] Responsive on mobile
- [x] No layout shifts or visual glitches

---

## Technical Checklist
- [x] Uses only HTML, CSS, and JavaScript
- [x] Follows existing code structure and style
- [x] No console errors or warnings

---

## Performance Impact
- [x] No noticeable performance impact

---

## Accessibility Considerations
- [x] Keyboard navigable
- [x] Click targets are touch-friendly

---

## Additional Notes
This is a CSS-only fix and does not affect JavaScript logic or backend functionality.
