### PR TITLE
Fix accessibility hint for expiry & quantity info 

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -5621,7 +5621,6 @@ a:focus,
 .status-badge.reserved {
   background-color: #ff9800;
 }
-=======
 
 .empty-state {
   grid-column: 1 / -1;
@@ -5645,4 +5644,15 @@ a:focus,
   color: #777;
 }
 
->>>>>>> a268cd3 (Move empty-state styles to CSS file)
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+

--- a/frontend/js/foodlisting.js
+++ b/frontend/js/foodlisting.js
@@ -935,12 +935,22 @@ if (expiryStatus.expired) {
                 <h3 class="food-title">${listing.foodType}</h3>
                 ${tagsHTML} 
                 <p class="food-description">${listing.description}</p>
-                <div class="food-meta">
-                    <span class="quantity"><i class="fas fa-utensils"></i> ${listing.quantity}</span>
-                    <span class="freshness"><i class="fas fa-clock"></i> ${freshUntil}</span>
+            <div class="food-meta" aria-describedby="foodMetaHelp-${listing.id}">
+                <span class="quantity">
+                <i class="fas fa-utensils"></i>
+                   Quantity: ${listing.quantity || "Not available"}
+                </span>
+                <span class="freshness">
+                <i class="fas fa-clock"></i>
+                  Expiry: ${freshUntil || "Not available"}
+                </span>
+             </div>
+
+            <p id="foodMetaHelp-${listing.id}" class="sr-only">
+                Food listing details: expiry time and available quantity.
+            </p>
 
 
-                </div>
                 <div class="food-location">
                     <i class="fas fa-map-marker-alt"></i>
                     <span>${listing.location}</span>


### PR DESCRIPTION
### PR Description

**Summary**

This PR improves accessibility for the food listing metadata by adding clear screen reader context for expiry time and quantity information.
Previously, screen readers could read the values but without proper context, which could confuse visually impaired users regarding food urgency and availability.

**Problem**

Screen readers did not clearly announce the purpose of:

Expiry time / Fresh-until

Quantity

This could lead to misunderstanding food urgency (e.g., whether the food is expiring soon).

**Solution Implemented**

 Added accessible context using ARIA attributes and improved the readability of expiry + quantity content.

**Changes included:**

Added aria-describedby support for the metadata section

Added a hidden helper description using .sr-only so screen readers get additional context

Added fallback values ("Not available") to avoid empty/unclear announcements when backend data is missing

**Files Changed**

_frontend/js/foodlisting.js_

Updated food listing card metadata block (expiry + quantity)

Added aria-describedby linking metadata to screen-reader-only description

Added fallback values for expiry & quantity

 _frontend/css/style.css_

Added .sr-only utility class for accessible hidden text

Accessibility Improvements

✅ **Screen readers now announce expiry + quantity with proper context like:**

“Quantity: 3”

“Expiry: 2 hours left”

and includes an additional description:
“Food listing details: expiry time and available quantity.”

✅ Works even if backend food data is not available (fallback text will be read instead).

**Testing Done**

Verified UI still displays expiry and quantity correctly on the food listing page

Checked that the metadata section includes ARIA support in the DOM

Confirmed fallback values appear if expiry/quantity is missing

#Reference

Closes / Fixes: #415
