### PR TITLE
fix(dark mode): correct heading contrast for #features and #about sec…

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -67,7 +67,11 @@ body.dark-mode {
   --glass-border: rgba(255, 255, 255, 0.1);
   --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
 }
-
+/* Dark mode: sections that remain white */
+body.dark-mode #features .section-title,
+body.dark-mode #about .section-title {
+  color: #333333;
+}
 /* Reset */
 *,
 *::before,


### PR DESCRIPTION


## 📝 Description

This PR fixes a dark mode visibility issue where section headings on the Home page were not clearly visible due to incorrect text color contrast.

Specifically:
- The headings inside `#features` and `#about` sections were inheriting incorrect color styles in dark mode.
- Since these sections retain a white background even in dark mode, their headings needed to be explicitly set to black for proper readability.

This update ensures correct contrast without affecting other dark-background sections.

---

## 🔗 Related Issue

Closes #577 

---

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

---

## 📸 Screenshots (if applicable)

### Before
<img width="1189" height="510" alt="Screenshot 2026-02-15 032928" src="https://github.com/user-attachments/assets/329afd19-4996-4231-9480-aa0b3a5c8529" />
<img width="1194" height="542" alt="Screenshot 2026-02-15 032936" src="https://github.com/user-attachments/assets/99c6983b-1460-4cde-b592-6946d5a42ecd" />


### After
<img width="1072" height="521" alt="Screenshot 2026-02-16 033500" src="https://github.com/user-attachments/assets/f55483dd-bdaf-4b7b-897d-02cb1011112b" />
<img width="943" height="419" alt="Screenshot 2026-02-16 033512" src="https://github.com/user-attachments/assets/12c1c964-030d-4b20-a54c-49f7f453306f" />


---

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to documentation (not required)
- [x] My changes generate no new warnings
- [x] I have tested my changes locally

---

## 🧪 Testing

- [x] Tested on Chrome
- [ ] Tested on Firefox
- [ ] Tested on mobile

Dark mode toggle verified on Home page sections.