### PR TITLE
fix(auth): correct reversed password visibility toggle icon logic

### DIFF
--- a/frontend/login.html
+++ b/frontend/login.html
@@ -465,7 +465,7 @@
       togglePassword.addEventListener("click", () => {
         passwordVisible = !passwordVisible;
         passwordInput.type = passwordVisible ? "text" : "password";
-        togglePassword.innerHTML = passwordVisible ? eyeOffIcon : eyeIcon;
+        togglePassword.innerHTML = passwordVisible ? eyeIcon: eyeOffIcon ;
         togglePassword.title = passwordVisible
           ? "Hide Password"
           : "Show Password";


### PR DESCRIPTION
## 📝 Description

This PR fixes a UI logic issue in the password visibility toggle button.

Previously:
- When the password was hidden, an open eye icon was displayed.
- When the password was visible, a crossed eye icon was displayed.

This behavior was reversed and inconsistent with standard UX expectations.

Now:
- Hidden password → crossed eye icon
- Visible password → open eye icon

The icon correctly represents the current visibility state.

---

## 🔗 Related Issue

Closes #576 

---

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

---

## 📸 Screenshots

### Before
Icon state was reversed relative to password visibility.
<img width="359" height="229" alt="Screenshot 2026-02-15 032651" src="https://github.com/user-attachments/assets/0ffccd95-d812-438c-a13d-05fc1e5c06bd" />


### After
Icon correctly reflects password visibility state.
<img width="367" height="207" alt="Screenshot 2026-02-16 035126" src="https://github.com/user-attachments/assets/3ec42bac-a83a-4155-a9cf-0671a4b74fd4" />
<img width="368" height="216" alt="Screenshot 2026-02-16 035120" src="https://github.com/user-attachments/assets/1e85fdcf-0650-4208-9600-a968cfd37a99" />


---

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tested locally
- [x] No new console warnings

---

## 🧪 Testing

- [x] Tested on Chrome
- [ ] Tested on Firefox
- [ ] Tested on mobile

Verified toggle behavior:
- Password hidden → crossed eye
- Password visible → open eye