### PR TITLE
fix(theme): correct dark mode selector to html.dark for proper toggle…

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -54,7 +54,7 @@
 }
 
 /* Dark Mode Variables */
-body.dark-mode {
+html.dark {
   --white: #1e1e1e;
   /* Dark card bg */
   --bg-light: #121212;


### PR DESCRIPTION
## 🐛 Bug Description

Dark mode toggle was not working on Listing Page because the CSS selector did not correctly match the class being added by JavaScript and also dark theme styling was being added to body instead of whole html.

## 🔗 Related Issue

Closes #578

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Screenshot
<img width="1223" height="575" alt="Screenshot 2026-02-16 053837" src="https://github.com/user-attachments/assets/e0bdc915-8564-4085-aeb3-e638e1b67cc3" />


## 📝 What Was Done

- Updated CSS selector to use `html.dark` instead of `.dark-mode`
- Ensured consistency between JS theme logic and CSS dark mode styles
- Verified that dark mode now properly toggles across pages

## ✅ Testing

- [x] Tested on Home page
- [x] Tested on Listings page
- [x] Verified class is correctly added/removed from `<html>`
- [x] Confirmed dark mode persists using localStorage

## 📋 Additional Notes

This fix ensures that theme toggling works consistently across all pages by aligning CSS selectors with the class applied in JavaScript.