### PR TITLE
Fix - 'map view' color transition in dark mode and remove inline styling

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -194,7 +194,27 @@ img {
   outline: 2px solid var(--primary-green);
   outline-offset: 3px;
 }
+.view-map-btn {
+  background: var(--bg-white);
+  color: var(--text-dark);
+  border: 1px solid var(--border-light);
+  padding: 0.8rem 1.5rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  margin-right: 10px;
+  font-weight: 500;
+}
 
+.view-map-btn i {
+  color: var(--primary);
+}
+
+/* Dark mode */
+html.dark .view-map-btn {
+  background: var(--bg-dark);
+  color: var(--text-light);
+  border: 1px solid var(--border-light);
+}
 /* Redirect-style buttons (used for View All Stories, Join Our Mission) */
 .btn-redirect {
   background: var(--primary-green);

--- a/frontend/foodlisting.html
+++ b/frontend/foodlisting.html
@@ -107,8 +107,8 @@
           <input type="text" placeholder="Search location or food..." />
         </div>
 
-        <button class="view-map-btn" onclick="window.location.href='map.html'"
-          style="background: var(--bg-white); color: var(--text-dark); border: 1px solid var(--border-light); padding: 0.8rem 1.5rem; border-radius: var(--radius-sm); cursor: pointer; margin-right: 10px; font-weight: 500; transition: all 0.3s ease;">
+        <button class="view-map-btn" onclick="window.location.href='map.html'">
+
           <i class="fas fa-map-marked-alt" style="color: var(--primary);"></i> Map View
         </button>
         <button class="add-listing-btn" id="addListingBtn">


### PR DESCRIPTION
## 🐛 Bug Description

On the Listings page, the "Map View" button text was not visible in Dark Mode due to improper color contrast.  
Additionally, the button styling was defined using inline styles, which made theme-based styling inconsistent and harder to maintain.

---

## 🔗 Related Issue

Closes #590 

---

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🎨 Style/UI update

---
### Screenshot
In Light mode
<img width="686" height="209" alt="Screenshot 2026-02-20 031112" src="https://github.com/user-attachments/assets/d1b49c97-7f56-43da-a716-de45aa3f2c4d" />

In Dark Mode
<img width="570" height="204" alt="Screenshot 2026-02-20 031117" src="https://github.com/user-attachments/assets/ada3e593-b57b-4b48-8acf-5399a81c1ade" />

---
## 📝 What Was Done

- Removed inline styles from the "Map View" button.
- Moved styling to CSS for better maintainability.
- Ensured proper text contrast in both Light and Dark modes.
- Preserved the existing map icon and layout.

---

## ✅ Testing

- [x] Tested in Light Mode
- [x] Tested in Dark Mode
- [x] Verified proper visibility and contrast
- [x] Confirmed no layout or spacing issues

---

## 📋 Additional Notes

This fix improves UI consistency and ensures proper theme compatibility across the Listings page.